### PR TITLE
Trying to fix undo/redo

### DIFF
--- a/INPUT/KEYBOARD.BM
+++ b/INPUT/KEYBOARD.BM
@@ -102,14 +102,14 @@ END SUB
 ' Handle keyboard input
 ' 
 SUB KEYBOARD_input_handler ()
-    DIM k as LONG
     DIM keypress AS STRING
-    k& = _KEYHIT
     keypress$ = INKEY$
-    KEYBOARD_colors keypress$
-    KEYBOARD_tools keypress$
-    KEYBOARD_brush_size keypress$
-    KEYBOARD_assistants keypress$
+    IF keypress$ <> "" THEN
+        KEYBOARD_colors keypress$
+        KEYBOARD_tools keypress$
+        KEYBOARD_brush_size keypress$
+        KEYBOARD_assistants keypress$
+    END IF
 END SUB
 
 

--- a/INPUT/MOUSE.BM
+++ b/INPUT/MOUSE.BM
@@ -58,13 +58,16 @@ SUB MOUSE_input_handler ()
                     IF MOUSE.Y% < MOUSE.OLD_Y% THEN MOUSE.DRAG$ = "U"
                     IF MOUSE.Y% > MOUSE.OLD_Y% THEN MOUSE.DRAG$ = "D"
                     PAINT_on
-                    ' Save state after first draw of this mouse click (button down event)
-                    IF NOT MOUSE.OLD_B1% AND NOT saved_state_this_frame% THEN
-                        UNDO_save_state
-                        saved_state_this_frame% = TRUE
-                    END IF
             END SELECT
         ELSE
+            ' Button released - save undo state if we were drawing
+            IF MOUSE.OLD_B1% AND NOT saved_state_this_frame% THEN
+                SELECT CASE CURRENT_TOOL%
+                    CASE TOOL_BRUSH, TOOL_DOT, TOOL_LINE
+                        UNDO_save_state
+                        saved_state_this_frame% = TRUE
+                END SELECT
+            END IF
             MOUSE.DRAG$ = ""
             MOUSE.CON_X% = 0 : MOUSE.CON_Y% = 0
             CONSTRAIN_X% = FALSE : CONSTRAIN_Y% = FALSE


### PR DESCRIPTION
This pull request refines input handling for both keyboard and mouse events, focusing on improving responsiveness and undo functionality. The main changes involve optimizing how keyboard input is processed and ensuring undo states are saved correctly when mouse drawing actions are completed.

**Keyboard Input Handling Improvements:**

* The `KEYBOARD_input_handler` subroutine now processes input only when a key is actually pressed, reducing unnecessary function calls and improving efficiency. (`INPUT/KEYBOARD.BM`, [INPUT/KEYBOARD.BML105-R112](diffhunk://#diff-6dd1e43f54113c796054ab4e7738ec2096b6d17d9d965e9c52a076ff0f99f9e4L105-R112))

**Mouse Drawing Undo Logic:**

* The undo state for mouse drawing actions is now saved when the mouse button is released, specifically for drawing tools (`TOOL_BRUSH`, `TOOL_DOT`, `TOOL_LINE`), rather than on button down. This ensures undo history is only updated after a completed drawing action. (`INPUT/MOUSE.BM`, [INPUT/MOUSE.BML61-R70](diffhunk://#diff-ed7f383520788930bee9b10e0ea7a377171447c37d0e3068da4954dfaf3403aeL61-R70))