### PR TITLE
Perf imp 2

### DIFF
--- a/CORE/HELP.BI
+++ b/CORE/HELP.BI
@@ -61,6 +61,7 @@ IF HELP_showHelp% OR HELP_showVer% THEN
         PRINT "      --reset-defaults      Restore factory configuration"
         PRINT "      --canvas-size WxH     Override startup canvas size (e.g. 320x200)"
         PRINT "      --portable            Keep config/data beside the executable"
+        PRINT "      --perf                Enable render-pipeline profiling (logs to DRAW.log)"
         PRINT
         PRINT "Examples:"
         PRINT "  DRAW myproject.draw"

--- a/CORE/HELP.BI
+++ b/CORE/HELP.BI
@@ -61,7 +61,7 @@ IF HELP_showHelp% OR HELP_showVer% THEN
         PRINT "      --reset-defaults      Restore factory configuration"
         PRINT "      --canvas-size WxH     Override startup canvas size (e.g. 320x200)"
         PRINT "      --portable            Keep config/data beside the executable"
-        PRINT "      --perf                Enable render-pipeline profiling (logs to DRAW.log)"
+        PRINT "      --perf                Enable render-pipeline profiling (writes DRAW-perf.log)"
         PRINT
         PRINT "Examples:"
         PRINT "  DRAW myproject.draw"

--- a/CORE/PERF.BI
+++ b/CORE/PERF.BI
@@ -43,9 +43,17 @@ CONST PERF_LOG_INTERVAL = 120
 DIM SHARED PERF_ENABLED AS INTEGER
 PERF_ENABLED% = FALSE
 
+' Log-file handle (lazy-opened on first PERF report write so we don't depend
+' on PATHS.BI being included first).  0 = not yet opened.
+DIM SHARED PERF_LOG_FH AS INTEGER
+DIM SHARED PERF_LOG_PATH$
+PERF_LOG_FH%   = 0
+PERF_LOG_PATH$ = "DRAW-perf.log"
+
 ' Enable via --perf command-line flag (scanned at include time so it takes
-' effect before SCREEN_init / first render). Once on, _LOGINFO emits a
-' per-section average + max timing report every PERF_LOG_INTERVAL frames.
+' effect before SCREEN_init / first render). Once on, every PERF_LOG_INTERVAL
+' frames a per-section average + max timing report is emitted to both the
+' console (_LOGINFO) and DRAW-perf.log (next to the working directory).
 DIM PERF_cmdIdx%
 DIM PERF_cmdVal$
 PERF_cmdIdx% = 1

--- a/CORE/PERF.BI
+++ b/CORE/PERF.BI
@@ -43,6 +43,21 @@ CONST PERF_LOG_INTERVAL = 120
 DIM SHARED PERF_ENABLED AS INTEGER
 PERF_ENABLED% = FALSE
 
+' Enable via --perf command-line flag (scanned at include time so it takes
+' effect before SCREEN_init / first render). Once on, _LOGINFO emits a
+' per-section average + max timing report every PERF_LOG_INTERVAL frames.
+DIM PERF_cmdIdx%
+DIM PERF_cmdVal$
+PERF_cmdIdx% = 1
+DO WHILE PERF_cmdIdx% <= _COMMANDCOUNT
+    PERF_cmdVal$ = LCASE$(_TRIM$(COMMAND$(PERF_cmdIdx%)))
+    IF PERF_cmdVal$ = "--perf" THEN
+        PERF_ENABLED% = TRUE
+        EXIT DO
+    END IF
+    PERF_cmdIdx% = PERF_cmdIdx% + 1
+LOOP
+
 ' Timing accumulators (sum over interval)
 DIM SHARED PERF_sum(0 TO PERF_SECTION_COUNT - 1) AS DOUBLE
 ' Per-frame start time scratch

--- a/CORE/PERF.BM
+++ b/CORE/PERF.BM
@@ -17,6 +17,36 @@ $INCLUDEONCE
 
 
 ''
+' Emit a PERF log line to both console (_LOGINFO) and the perf log file.
+' Lazy-opens the file on first call so it works regardless of include
+' ordering relative to PATHS.BI.
+'
+SUB PERF_log (msg AS STRING)
+    _LOGINFO msg
+    IF PERF_LOG_FH% = 0 THEN
+        PERF_LOG_FH% = FREEFILE
+        OPEN PERF_LOG_PATH$ FOR OUTPUT AS #PERF_LOG_FH%
+        PRINT #PERF_LOG_FH%, "DRAW " + APP_VERSION$ + " --perf log, started " + DATE$ + " " + TIME$
+        PRINT #PERF_LOG_FH%, "Canvas: " + _TRIM$(STR$(SCRN.canvasW&)) + "x" + _TRIM$(STR$(SCRN.canvasH&)) + _
+                             "  Viewport: " + _TRIM$(STR$(SCRN.w&)) + "x" + _TRIM$(STR$(SCRN.h&))
+        PRINT #PERF_LOG_FH%, "----"
+    END IF
+    PRINT #PERF_LOG_FH%, msg
+END SUB
+
+
+''
+' Close the PERF log file (called from MAIN_shutdown).
+'
+SUB PERF_log_close ()
+    IF PERF_LOG_FH% <> 0 THEN
+        CLOSE #PERF_LOG_FH%
+        PERF_LOG_FH% = 0
+    END IF
+END SUB
+
+
+''
 ' Begin timing a section
 ' @param section INTEGER Performance section index (PERF_* constant)
 '
@@ -71,7 +101,7 @@ SUB PERF_frame_end ()
             render_avg# = 0
         END IF
 
-        _LOGINFO "==== PERF REPORT (" + _TRIM$(STR$(PERF_frame_count)) + " frames) ===="
+        PERF_log "==== PERF REPORT (" + _TRIM$(STR$(PERF_frame_count)) + " frames) ===="
 
         ' Path distribution
         DIM gui_hits AS LONG, dr_hits AS LONG, full_hits AS LONG, total_renders AS LONG
@@ -80,7 +110,7 @@ SUB PERF_frame_end ()
         full_hits&     = PERF_hits(PERF_FULL_CLS_GUI) ' Full path always hits CLS+GUI
         total_renders& = PERF_hits(PERF_RENDER_TOTAL)
         IF total_renders& > 0 THEN
-            _LOGINFO "  Path distribution: GUI-only=" + _TRIM$(STR$(gui_hits&)) + _
+            PERF_log "  Path distribution: GUI-only=" + _TRIM$(STR$(gui_hits&)) + _
                      " DirtyRect=" + _TRIM$(STR$(dr_hits&)) + _
                      " Full=" + _TRIM$(STR$(full_hits&)) + _
                      " Idle(skipped)=" + _TRIM$(STR$(PERF_frame_count - total_renders&))
@@ -104,7 +134,7 @@ SUB PERF_frame_end ()
                                 " hits=" + _TRIM$(STR$(PERF_hits(i%)))
                 END IF
 
-                _LOGINFO line_out$
+                PERF_log line_out$
             END IF
         NEXT i%
 
@@ -115,12 +145,12 @@ SUB PERF_frame_end ()
         DIM budget_ms AS DOUBLE
         budget_ms# = 1000.0 / fps%
         IF render_avg# > 0 THEN
-            _LOGINFO "  Frame budget: " + PERF_format_ms$(budget_ms#) + _
+            PERF_log "  Frame budget: " + PERF_format_ms$(budget_ms#) + _
                      " @ " + _TRIM$(STR$(fps%)) + "fps" + _
                      " | Render uses " + _TRIM$(STR$(INT(render_avg# / budget_ms# * 100))) + "%"
         END IF
 
-        _LOGINFO "==== END PERF ===="
+        PERF_log "==== END PERF ===="
 
         ' Reset accumulators
         FOR i% = 0 TO PERF_SECTION_COUNT - 1

--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -932,6 +932,9 @@ SUB MAIN_shutdown ()
     ' =====================================================================
     SOUND_close_all
 
+    ' Flush + close the --perf log file (no-op when --perf wasn't enabled)
+    PERF_log_close
+
     SYSTEM
 END SUB
 

--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -735,6 +735,7 @@ SUB MAIN_shutdown ()
     ' FREE MAIN SCREEN BUFFERS
     ' =====================================================================
     IF SCRN.CANVAS& < -1 THEN _FREEIMAGE SCRN.CANVAS&
+    IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
     IF SCRN.PAINTING& < -1 THEN _FREEIMAGE SCRN.PAINTING&
     IF SCRN.GUI& < -1 THEN _FREEIMAGE SCRN.GUI&
     ' SCRN.CURSOR& no longer allocated — cursors draw directly onto SCRN.CANVAS&

--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -116,6 +116,8 @@ $IF MAC THEN
                 macArgIdx% = macArgIdx% + 1 ' Skip flag only
             ELSEIF LCASE$(macArgVal$) = "--reset-defaults" THEN
                 macArgIdx% = macArgIdx% + 1 ' Skip flag only
+            ELSEIF LCASE$(macArgVal$) = "--perf" THEN
+                macArgIdx% = macArgIdx% + 1 ' Skip flag only (consumed by PERF.BI)
             ELSEIF LCASE$(macArgVal$) = "--help" OR LCASE$(macArgVal$) = "-h" OR _
                    LCASE$(macArgVal$) = "/?" OR LCASE$(macArgVal$) = "-?" OR _
                    LCASE$(macArgVal$) = "/h" OR LCASE$(macArgVal$) = "/help" OR _
@@ -144,6 +146,8 @@ $ELSE
             argIdx% = argIdx% + 1 ' Skip flag only
         ELSEIF LCASE$(argVal$) = "--reset-defaults" THEN
             argIdx% = argIdx% + 1 ' Skip flag only
+        ELSEIF LCASE$(argVal$) = "--perf" THEN
+            argIdx% = argIdx% + 1 ' Skip flag only (consumed by PERF.BI)
         ELSEIF LCASE$(argVal$) = "--help" OR LCASE$(argVal$) = "-h" OR _
                LCASE$(argVal$) = "/?" OR LCASE$(argVal$) = "-?" OR _
                LCASE$(argVal$) = "/h" OR LCASE$(argVal$) = "/help" OR _
@@ -786,11 +790,13 @@ SUB MAIN_shutdown ()
     ' =====================================================================
     ' Grid system
     IF GRID.imgHandle& < -1 THEN _FREEIMAGE GRID.imgHandle&
+    IF GRID.ssCacheImg& < -1 THEN _FREEIMAGE GRID.ssCacheImg&
     IF PIXEL_GRID.imgHandle& < -1 THEN _FREEIMAGE PIXEL_GRID.imgHandle&
     ' Symmetry guides
     IF SYMMETRY.imgHandle& < -1 THEN _FREEIMAGE SYMMETRY.imgHandle&
-    ' Transparency checkerboard
+    ' Transparency checkerboard (two-level cache: display + canvas-res blueprint)
     IF TRANSPARENCY.imgHandle& < -1 THEN _FREEIMAGE TRANSPARENCY.imgHandle&
+    IF TRANSPARENCY.blueprint& < -1 THEN _FREEIMAGE TRANSPARENCY.blueprint&
 
     ' =====================================================================
     ' FREE ORGANIZER WIDGET IMAGES

--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -619,9 +619,12 @@ DO
     '  sets the window to the correct size immediately; no retry needed.)
     
     ' Apply frame rate limit AFTER render+display (reduced when idle).
-    ' Cursor-only movement uses CFG.FPS_CURSOR% (default 240) — the
-    ' STATUS-ONLY and dirty-rect paths are ultra-lightweight partial
-    ' blits, so high FPS is cheap and makes the cursor responsive.
+    ' Cursor-only movement historically used CFG.FPS_CURSOR% (default 240)
+    ' because the STATUS-ONLY and dirty-rect partial paths were ultra-light
+    ' (~1ms).  With those paths disabled to fix HW final-scale ghost trails,
+    ' every cursor move now triggers a full render (~7ms), so 240 FPS would
+    ' burn ~1700ms/sec of CPU.  Cap at FPS_LIMIT (60) — same cap as steady
+    ' rendering, keeps CPU usage reasonable.
     DIM cursorOnlyMove AS INTEGER
     cursorOnlyMove% = (mouseMoved% AND NOT SCENE_CHANGED% _
                        AND NOT MOUSE.B1% AND NOT MOUSE.B2% AND NOT MOUSE.B3%)
@@ -629,7 +632,7 @@ DO
     IF FRAME_IDLE% THEN
         _LIMIT CFG.FPS_IDLE%
     ELSEIF cursorOnlyMove% THEN
-        _LIMIT CFG.FPS_CURSOR%
+        _LIMIT CFG.FPS_LIMIT%
     ELSEIF MOVE.ACTIVE AND CURRENT_TOOL% = TOOL_MOVE THEN
         ' Throttle MOVE drag — full-canvas re-composite per frame is expensive
         ' and 30 fps is plenty for drag responsiveness. Cap at min(FPS_LIMIT, 30).

--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -735,7 +735,6 @@ SUB MAIN_shutdown ()
     ' FREE MAIN SCREEN BUFFERS
     ' =====================================================================
     IF SCRN.CANVAS& < -1 THEN _FREEIMAGE SCRN.CANVAS&
-    IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
     IF SCRN.PAINTING& < -1 THEN _FREEIMAGE SCRN.PAINTING&
     IF SCRN.GUI& < -1 THEN _FREEIMAGE SCRN.GUI&
     ' SCRN.CURSOR& no longer allocated — cursors draw directly onto SCRN.CANVAS&

--- a/EXPERIMENTS/ALPHA_PRESERVE_TEST.BAS
+++ b/EXPERIMENTS/ALPHA_PRESERVE_TEST.BAS
@@ -1,0 +1,74 @@
+''
+' Alpha Preserve Test — does QB64-PE's alpha-blend draw preserve destination
+' alpha (proper source-over compositing) or overwrite it (naive)?
+'
+' Setup:
+'   1. Create a 32-bit software image
+'   2. Fill it with opaque white (alpha = 255 everywhere)
+'   3. Draw a LINE BF with _RGBA32(R, G, B, 240) — semi-transparent
+'   4. Check the alpha at a pixel inside the drawn rect
+'
+' Expected results:
+'   Proper alpha compositing: dest alpha stays 255 (A_out = A_src + A_dst*(1-A_src))
+'   Naive overwrite:          dest alpha becomes 240 (A_out = A_src)
+'
+' If naive, DRAW's semi-transparent tooltip bg leaves alpha-240 pixels on
+' SCRN.CANVAS, which then make their way through _COPYIMAGE(,33) to the
+' hardware image, and the HW present alpha-blends those pixels with the
+' GL framebuffer — causing accumulation/ghost trails when source alpha < 255.
+'
+$CONSOLE
+
+SCREEN _NEWIMAGE(400, 200, 32)
+
+DIM img AS LONG : img = _NEWIMAGE(100, 100, 32)
+_DEST img
+_BLEND img
+CLS , _RGBA32(255, 255, 255, 255)   ' opaque white
+
+' Draw a semi-transparent red rect with alpha 240
+LINE (10, 10)-(70, 70), _RGBA32(255, 0, 0, 240), BF
+
+DIM px AS _UNSIGNED LONG
+px = POINT(30, 30)
+DIM r AS LONG, g AS LONG, b AS LONG, a AS LONG
+r = _RED32(px)
+g = _GREEN32(px)
+b = _BLUE32(px)
+a = _ALPHA32(px)
+
+_DEST 0
+CLS , _RGB32(0, 0, 0)
+COLOR _RGB32(255, 255, 255), _RGB32(0, 0, 0)
+PRINT
+PRINT " Pixel at (30, 30) of semi-transparent (alpha=240) draw on opaque dest:"
+PRINT
+PRINT "   R = "; r
+PRINT "   G = "; g
+PRINT "   B = "; b
+PRINT "   A = "; a
+PRINT
+IF a = 255 THEN
+    COLOR _RGB32(0, 255, 0)
+    PRINT " RESULT: Alpha preserved at 255 = proper source-over compositing."
+    PRINT "         DRAW's tooltip alpha bg should NOT cause HW ghost trails."
+ELSE
+    COLOR _RGB32(255, 100, 100)
+    PRINT " RESULT: Alpha is "; a; " < 255 = NAIVE overwrite (not proper compositing)."
+    PRINT "         DRAW's tooltip alpha bg DOES cause SCRN.CANVAS to have sub-255"
+    PRINT "         alpha pixels.  HW present alpha-blends them with GL framebuffer,"
+    PRINT "         causing ghost-trail accumulation when path alternates."
+END IF
+PRINT
+COLOR _RGB32(200, 200, 200)
+PRINT " Press any key to exit."
+
+_DEST img
+DIM k AS LONG
+DO
+    k = _KEYHIT
+    _LIMIT 30
+LOOP UNTIL k > 0
+
+_FREEIMAGE img
+SYSTEM

--- a/EXPERIMENTS/HW_ALPHA_GHOST_TEST.BAS
+++ b/EXPERIMENTS/HW_ALPHA_GHOST_TEST.BAS
@@ -1,0 +1,94 @@
+''
+' HW Alpha Ghost Test — verify that drawing semi-transparent (alpha < 255)
+' content to a software canvas, then _COPYIMAGE'ing to HW and blitting to
+' screen 0, causes the source alpha to bleed through and leave ghost trails
+' from previous frames.
+'
+' Pattern:
+'   1. Each frame, fully CLS canvas to opaque background (alpha=255 everywhere)
+'   2. Draw a moving "tooltip" rectangle with alpha=240 (NOT 255 — this is
+'      the actual DRAW tooltip default at TOOLTIP.BM:550)
+'   3. _COPYIMAGE(canvas, 33), _PUTIMAGE to screen 0
+'
+' If the moving tooltip leaves trails on screen 0, the hypothesis is
+' confirmed: semi-transparent content on the source canvas causes alpha
+' to leak through the HW path, preserving stale screen 0 pixels.
+'
+' Modes:
+'   1 — Tooltip alpha 240 (matches DRAW)
+'   2 — Tooltip alpha 255 (forced opaque — should be clean)
+'   3 — Tooltip alpha 240 + _SETALPHA 255 on canvas before _COPYIMAGE
+'       (forces destination alpha back to 255 to override the leak)
+'   ESC — quit
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Alpha Ghost Test (1/2/3 modes, ESC quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+
+DIM frame  AS LONG : frame = 0
+DIM mode   AS INTEGER : mode = 1
+DIM cx     AS INTEGER : cx = CANVAS_W \ 2
+DIM cy     AS INTEGER : cy = CANVAS_H \ 2
+DIM dirX   AS INTEGER : dirX = 1
+DIM dirY   AS INTEGER : dirY = 1
+DIM k      AS LONG
+
+DO
+    frame = frame + 1
+
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k >= ASC("1") AND k <= ASC("3") THEN mode = k - ASC("0")
+
+    ' === Update canvas ===
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGBA32(0, 0, 64, 255)  ' opaque dark blue
+    _BLEND canvas
+
+    ' Move "tooltip" position
+    cx = cx + dirX : cy = cy + dirY
+    IF cx <= 10 OR cx >= CANVAS_W - 10 THEN dirX = -dirX
+    IF cy <= 10 OR cy >= CANVAS_H - 10 THEN dirY = -dirY
+
+    ' Draw "tooltip" — semi-transparent in mode 1 (matches DRAW behavior),
+    ' fully opaque in mode 2 (control).  Mode 3 uses semi-transparent but
+    ' force-sets canvas alpha to 255 before _COPYIMAGE.
+    DIM tipAlpha AS INTEGER
+    SELECT CASE mode
+        CASE 1: tipAlpha = 240
+        CASE 2: tipAlpha = 255
+        CASE 3: tipAlpha = 240
+    END SELECT
+
+    LINE (cx - 8, cy - 8)-(cx + 8, cy + 8), _RGBA32(255, 255, 100, tipAlpha), BF
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " alpha=" + LTRIM$(STR$(tipAlpha)) + " F=" + LTRIM$(STR$(frame))
+
+    ' Mode 3: forcibly restore canvas alpha to 255 across the whole image
+    ' before snapshotting.  Slow but tests whether alpha-leak is the bug.
+    IF mode = 3 THEN
+        _SETALPHA 255, , canvas
+    END IF
+
+    ' === Present via HW path ===
+    IF hw < -1 THEN _FREEIMAGE hw
+    hw = _COPYIMAGE(canvas, 33)
+    _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+
+    _DISPLAY
+    _LIMIT 60
+LOOP
+
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/HW_IMAGE_TEST.BAS
+++ b/EXPERIMENTS/HW_IMAGE_TEST.BAS
@@ -1,0 +1,114 @@
+''
+' HW Image Test — isolate the QB64-PE hardware-image final-blit path
+' to reproduce (or rule out) the ghost-trail bug observed in DRAW.
+'
+' Pattern under test (matches DRAW's reverted optimization):
+'   1. Each frame, CLS a software canvas to an opaque background
+'   2. Draw an animated overlay on the software canvas
+'   3. _FREEIMAGE old hardware handle, _COPYIMAGE(canvas, 33) for new HW
+'   4. _PUTIMAGE HW to screen 0 with stretch (4x upscale)
+'   5. Repeat
+'
+' If the screen shows trailing/ghosted previous frames of the moving
+' overlay, the HW path itself is buggy (rules out DRAW's partial-present
+' paths).  If the moving overlay is clean, the bug is in DRAW's mix of
+' HW full-path and CPU partial-path rendering.
+'
+' Controls:
+'   ESC  — quit
+'   1    — _PUTIMAGE HW source (the simple variant)
+'   2    — _MAPTRIANGLE HW source (two triangles)
+'   3    — Original CPU _PUTIMAGE (no HW image, baseline)
+'   D    — toggle _DONTBLEND on HW image
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+CONST MODE_PUT_HW       = 1
+CONST MODE_MAPTRI_HW    = 2
+CONST MODE_PUT_SOFTWARE = 3
+
+' Set up screen 0 as 32-bit graphics, scaled up 4x
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Image Test (1/2/3 to switch path, D for dontblend, ESC to quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+
+DIM frame      AS LONG : frame = 0
+DIM mode       AS INTEGER : mode = MODE_PUT_HW
+DIM dontblend  AS INTEGER : dontblend = 0
+DIM circleX    AS INTEGER
+DIM circleY    AS INTEGER
+DIM dirX       AS INTEGER : dirX = 1
+DIM dirY       AS INTEGER : dirY = 1
+circleX = CANVAS_W \ 2
+circleY = CANVAS_H \ 2
+
+DIM k AS LONG
+
+DO
+    frame = frame + 1
+
+    ' === Handle input ===
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k = ASC("1") OR k = ASC("!") THEN mode = MODE_PUT_HW
+    IF k = ASC("2") OR k = ASC("@") THEN mode = MODE_MAPTRI_HW
+    IF k = ASC("3") OR k = ASC("#") THEN mode = MODE_PUT_SOFTWARE
+    IF k = ASC("d") OR k = ASC("D") THEN dontblend = 1 - dontblend
+
+    ' === Animate the software canvas ===
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGBA32(0, 0, 64, 255)  ' opaque dark blue background
+    _BLEND canvas
+
+    ' Move a white circle each frame.  If we see trails, the present path
+    ' is preserving previous frame pixels — that's the ghosting bug.
+    circleX = circleX + dirX
+    circleY = circleY + dirY
+    IF circleX <= 10 OR circleX >= CANVAS_W - 10 THEN dirX = -dirX
+    IF circleY <= 10 OR circleY >= CANVAS_H - 10 THEN dirY = -dirY
+
+    LINE (circleX - 8, circleY - 8)-(circleX + 8, circleY + 8), _RGB32(255, 255, 255), BF
+
+    ' Mode indicator text on canvas
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " DB=" + LTRIM$(STR$(dontblend)) + " Frame " + LTRIM$(STR$(frame))
+
+    ' === Present to screen 0 using the selected path ===
+    SELECT CASE mode
+        CASE MODE_PUT_HW
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            IF dontblend THEN _DONTBLEND hw
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+
+        CASE MODE_MAPTRI_HW
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            IF dontblend THEN _DONTBLEND hw
+            DIM oldDest AS LONG : oldDest = _DEST
+            _DEST 0
+            _MAPTRIANGLE (0, 0)-(0, CANVAS_H - 1)-(CANVAS_W - 1, CANVAS_H - 1), hw TO (0, 0)-(0, WIN_H - 1)-(WIN_W - 1, WIN_H - 1)
+            _MAPTRIANGLE (0, 0)-(CANVAS_W - 1, 0)-(CANVAS_W - 1, CANVAS_H - 1), hw TO (0, 0)-(WIN_W - 1, 0)-(WIN_W - 1, WIN_H - 1)
+            _DEST oldDest
+
+        CASE MODE_PUT_SOFTWARE
+            ' Baseline: no HW image, direct CPU upscale (original DRAW path)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), canvas, 0
+    END SELECT
+
+    _DISPLAY
+    _LIMIT 60
+LOOP
+
+' Cleanup
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/HW_PARTIAL_BOUNDARY_TEST.BAS
+++ b/EXPERIMENTS/HW_PARTIAL_BOUNDARY_TEST.BAS
@@ -1,0 +1,105 @@
+''
+' HW Partial Boundary Test — check whether HW full-present + CPU partial-blit
+' produces visible artifacts at the boundary of the partial rect when source
+' content has high-contrast detail (tooltip-like text).
+'
+' Hypothesis: even though both paths nominally use nearest-neighbor, subtle
+' subpixel/rounding differences between GL texture stretch (HW) and software
+' nearest-neighbor (CPU) make seam pixels misalign at the partial-blit boundary.
+'
+' Layout:
+'   - Large yellow "tooltip" rectangle with HIGH CONTRAST stripes inside it
+'   - The tooltip extends ACROSS the partial-blit rect boundary
+'   - Each frame: full HW present → CPU partial blit of a section that
+'     partially overlaps the tooltip
+'   - If you see fragmented stripes at the partial rect's edge, hypothesis confirmed
+'
+' Modes:
+'   1 — HW full + CPU partial (the suspect)
+'   2 — CPU full + CPU partial (baseline — should be clean)
+'   ESC — quit
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+' Partial-blit rect (canvas coords) — vertically spans top half, horizontally right half
+CONST PART_X1 = CANVAS_W / 2
+CONST PART_Y1 = 0
+CONST PART_X2 = CANVAS_W - 1
+CONST PART_Y2 = CANVAS_H / 2
+
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Partial Boundary Test (1=HW+partial 2=CPU+partial ESC=quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+DIM mode   AS INTEGER : mode = 1
+DIM frame  AS LONG : frame = 0
+DIM tipX   AS INTEGER : tipX = 30
+DIM dir    AS INTEGER : dir = 1
+DIM k      AS LONG
+
+DO
+    frame = frame + 1
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k = ASC("1") THEN mode = 1
+    IF k = ASC("2") THEN mode = 2
+
+    ' Animate: a "tooltip" rect moves left-right, deliberately straddles the
+    ' partial-blit boundary at PART_X1 = CANVAS_W/2
+    tipX = tipX + dir
+    IF tipX < 30 OR tipX > CANVAS_W - 80 THEN dir = -dir
+
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGBA32(20, 20, 30, 255)
+    _BLEND canvas
+
+    ' Tooltip-like rectangle with internal high-contrast stripes
+    DIM ttW AS INTEGER : ttW = 60
+    DIM ttH AS INTEGER : ttH = 20
+    DIM ttY AS INTEGER : ttY = 30
+    LINE (tipX, ttY)-(tipX + ttW - 1, ttY + ttH - 1), _RGB32(40, 40, 50), BF
+    LINE (tipX, ttY)-(tipX + ttW - 1, ttY + ttH - 1), _RGB32(100, 100, 120), B
+    ' Internal stripes (every other pixel column white) — high contrast detail
+    DIM sx AS INTEGER
+    FOR sx = tipX + 2 TO tipX + ttW - 3 STEP 2
+        LINE (sx, ttY + 4)-(sx, ttY + ttH - 5), _RGB32(255, 255, 100)
+    NEXT sx
+
+    ' Visual indicator: the partial-blit boundary (red vertical line)
+    LINE (PART_X1, 0)-(PART_X1, CANVAS_H - 1), _RGB32(255, 0, 0)
+
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " F=" + LTRIM$(STR$(frame))
+
+    ' === Present ===
+    SELECT CASE mode
+        CASE 1
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+        CASE 2
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), canvas, 0
+    END SELECT
+
+    ' Then CPU partial overlay (right half, top half)
+    DIM wX1 AS LONG, wY1 AS LONG, wX2 AS LONG, wY2 AS LONG
+    wX1 = PART_X1 * SCALE
+    wY1 = PART_Y1 * SCALE
+    wX2 = PART_X2 * SCALE
+    wY2 = PART_Y2 * SCALE
+    _PUTIMAGE (wX1, wY1)-(wX2, wY2), canvas, 0, (PART_X1, PART_Y1)-(PART_X2, PART_Y2)
+
+    _DISPLAY
+    _LIMIT 60
+LOOP
+
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/HW_PARTIAL_MIX_TEST.BAS
+++ b/EXPERIMENTS/HW_PARTIAL_MIX_TEST.BAS
@@ -1,0 +1,123 @@
+''
+' HW Partial Mix Test — reproduce DRAW's ghost trails by mixing
+' HW full-frame present with CPU partial-rect overlays.
+'
+' Pattern under test:
+'   1. Each frame, animate content on software canvas
+'   2. Present full canvas to screen 0 via HW image (the "full path")
+'   3. Then do a CPU partial _PUTIMAGE from canvas to a SMALL rect of
+'      screen 0 (simulating DRAW's STATUS-only or dirty-rect partial paths)
+'   4. The partial rect deliberately does NOT cover the moving overlay's
+'      area — so if anything leaks, it's because the partial rect's pixel
+'      output differs from the HW path's pixel output at its boundary
+'
+' If you see seams, color discontinuities, or trailing pixels along the
+' boundary between the HW-rendered area and the CPU partial-rect area,
+' that's the bug.
+'
+' Modes:
+'   1 — HW full present every frame (no partial)
+'   2 — HW full present + CPU partial-rect overlay (DRAW's mixed pattern)
+'   3 — CPU full present + CPU partial-rect overlay (matches pre-HW DRAW)
+'   4 — HW full present every 2nd frame + CPU partial in between
+'       (simulates DRAW's full ↔ partial ping-pong)
+'   ESC — quit
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+' Partial-rect coverage area (in canvas coords).  Covers the upper-right
+' quadrant ONLY — the moving square is in the middle, so the partial
+' rect's boundary should never overlap the square.
+CONST PART_X1 = CANVAS_W / 2 + 10
+CONST PART_Y1 = 5
+CONST PART_X2 = CANVAS_W - 5
+CONST PART_Y2 = CANVAS_H / 2 - 10
+
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Partial Mix Test (1/2/3/4 modes, ESC quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+
+DIM frame  AS LONG : frame = 0
+DIM mode   AS INTEGER : mode = 2  ' Start in the suspected bug mode
+DIM cx     AS INTEGER : cx = CANVAS_W \ 2
+DIM cy     AS INTEGER : cy = CANVAS_H \ 2
+DIM dirX   AS INTEGER : dirX = 1
+DIM dirY   AS INTEGER : dirY = 1
+DIM k      AS LONG
+
+DO
+    frame = frame + 1
+
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k >= ASC("1") AND k <= ASC("4") THEN mode = k - ASC("0")
+
+    ' === Animate ===
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGBA32(0, 0, 64, 255)
+    _BLEND canvas
+
+    cx = cx + dirX : cy = cy + dirY
+    IF cx <= 10 OR cx >= CANVAS_W - 10 THEN dirX = -dirX
+    IF cy <= 10 OR cy >= CANVAS_H - 10 THEN dirY = -dirY
+    LINE (cx - 8, cy - 8)-(cx + 8, cy + 8), _RGB32(255, 255, 255), BF
+
+    ' Draw a static yellow rect in the upper-right (the "chrome" area).
+    ' The partial-rect overlay will redraw THIS area each frame.  If full
+    ' HW present and partial CPU present produce different pixels at the
+    ' boundary of this rect, we'll see artifacts.
+    LINE (PART_X1 + 4, PART_Y1 + 4)-(PART_X2 - 4, PART_Y2 - 4), _RGB32(200, 200, 0), BF
+    _PRINTSTRING (PART_X1 + 8, PART_Y1 + 8), "chrome"
+
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " Frame " + LTRIM$(STR$(frame))
+
+    ' === Present ===
+    DIM doHwFull AS INTEGER : doHwFull = 0
+    DIM doCpuFull AS INTEGER : doCpuFull = 0
+    DIM doPartial AS INTEGER : doPartial = 0
+
+    SELECT CASE mode
+        CASE 1: doHwFull = 1                                ' pure HW
+        CASE 2: doHwFull = 1: doPartial = 1                 ' HW + CPU partial (DRAW's pattern)
+        CASE 3: doCpuFull = 1: doPartial = 1                ' CPU + CPU partial (pre-HW pattern)
+        CASE 4
+            IF (frame MOD 2) = 1 THEN doHwFull = 1 ELSE doPartial = 1
+    END SELECT
+
+    IF doHwFull THEN
+        IF hw < -1 THEN _FREEIMAGE hw
+        hw = _COPYIMAGE(canvas, 33)
+        _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+    END IF
+
+    IF doCpuFull THEN
+        _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), canvas, 0
+    END IF
+
+    IF doPartial THEN
+        ' Partial _PUTIMAGE: just the upper-right quadrant in canvas coords,
+        ' mapped to the corresponding screen 0 rect.
+        DIM winX1 AS LONG, winY1 AS LONG, winX2 AS LONG, winY2 AS LONG
+        winX1 = PART_X1 * SCALE
+        winY1 = PART_Y1 * SCALE
+        winX2 = PART_X2 * SCALE
+        winY2 = PART_Y2 * SCALE
+        _PUTIMAGE (winX1, winY1)-(winX2, winY2), canvas, 0, (PART_X1, PART_Y1)-(PART_X2, PART_Y2)
+    END IF
+
+    _DISPLAY
+    _LIMIT 60
+LOOP
+
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/HW_SYNC_TEST.BAS
+++ b/EXPERIMENTS/HW_SYNC_TEST.BAS
@@ -1,0 +1,97 @@
+''
+' HW Sync Test — verify that HW _PUTIMAGE defers rendering until _DISPLAY,
+' causing subsequent CPU writes to screen 0 to be invisible.
+'
+' Modes:
+'   1 — HW _PUTIMAGE → CPU LINE → _DISPLAY (DRAW's current pattern)
+'   2 — HW _PUTIMAGE → _DISPLAY → CPU LINE → _DISPLAY (two flips, force sync)
+'   3 — CPU _PUTIMAGE → CPU LINE → _DISPLAY (CPU baseline)
+'   4 — HW _PUTIMAGE only (no CPU LINE) → _DISPLAY (control)
+'   ESC quit
+'
+' If mode 1 shows no panel but mode 2 does, then a forced flush between HW
+' and CPU operations is the workaround.
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Sync Test (1/2/3/4 modes, ESC quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+DIM mode   AS INTEGER : mode = 1
+DIM frame  AS LONG : frame = 0
+DIM k      AS LONG
+
+DO
+    frame = frame + 1
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k >= ASC("1") AND k <= ASC("4") THEN mode = k - ASC("0")
+
+    ' Render canvas with moving square + background grid
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGB32(20, 30, 50)
+    _BLEND canvas
+    DIM sx AS INTEGER
+    FOR sx = 0 TO CANVAS_W - 1 STEP 25
+        LINE (sx, 0)-(sx, CANVAS_H - 1), _RGB32(50, 60, 80)
+    NEXT sx
+
+    DIM mx AS INTEGER : mx = 30 + (frame \ 2) MOD (CANVAS_W - 60)
+    LINE (mx - 8, 30)-(mx + 8, 50), _RGB32(255, 255, 255), BF
+
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " F=" + LTRIM$(STR$(frame))
+
+    ' === Mode-specific present + CPU write ===
+    SELECT CASE mode
+        CASE 1
+            ' DRAW's pattern: HW present, then CPU LINE, then _DISPLAY
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+            _DEST 0
+            LINE (WIN_W / 2, WIN_H / 2)-(WIN_W - 50, WIN_H - 50), _RGB32(255, 100, 100), BF
+            _PRINTSTRING (WIN_W / 2 + 8, WIN_H / 2 + 8), "CPU PANEL"
+            _DISPLAY
+
+        CASE 2
+            ' Forced flush: HW present, _DISPLAY, then CPU LINE, _DISPLAY again
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+            _DISPLAY  ' Flush HW
+            _DEST 0
+            LINE (WIN_W / 2, WIN_H / 2)-(WIN_W - 50, WIN_H - 50), _RGB32(255, 100, 100), BF
+            _PRINTSTRING (WIN_W / 2 + 8, WIN_H / 2 + 8), "CPU PANEL"
+            _DISPLAY  ' Flush CPU
+
+        CASE 3
+            ' CPU baseline: CPU _PUTIMAGE, CPU LINE, _DISPLAY
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), canvas, 0
+            _DEST 0
+            LINE (WIN_W / 2, WIN_H / 2)-(WIN_W - 50, WIN_H - 50), _RGB32(255, 100, 100), BF
+            _PRINTSTRING (WIN_W / 2 + 8, WIN_H / 2 + 8), "CPU PANEL"
+            _DISPLAY
+
+        CASE 4
+            ' HW only, no CPU write (control)
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+            _DISPLAY
+    END SELECT
+
+    _LIMIT 60
+LOOP
+
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/HW_TOOLTIP_REBLIT_TEST.BAS
+++ b/EXPERIMENTS/HW_TOOLTIP_REBLIT_TEST.BAS
@@ -1,0 +1,127 @@
+''
+' HW Tooltip Reblit Test — replicate DRAW's TOOLTIP_reblit_to_screen0 pattern:
+'   1. Software canvas has full frame including a "tooltip" rect
+'   2. HW full present (entire screen 0 painted via HW path)
+'   3. Some "panel" drawn directly to screen 0, partially covering tooltip
+'   4. CPU partial _PUTIMAGE of JUST the tooltip rect from canvas to screen 0
+'      (mirroring TOOLTIP_reblit_to_screen0 exactly)
+'   5. _DISPLAY
+'
+' This is the EXACT pattern that fires in DRAW after every render path.
+' The tooltip rect on screen 0 gets painted twice: HW first, then CPU.
+' If they produce different pixels, the boundary of TOOLTIP.RENDER_W/H
+' becomes visible — which would look like "tooltip fragments" because
+' the tooltip exists in CPU pixels inside the rect, HW pixels just
+' outside the rect.
+'
+' Modes:
+'   1 — HW full + CPU re-blit (DRAW's exact pattern)
+'   2 — CPU full + CPU re-blit (pre-HW DRAW pattern)
+'   3 — HW full only (no re-blit)
+'   ESC quit
+'
+$RESIZE:OFF
+
+CONST CANVAS_W = 200
+CONST CANVAS_H = 150
+CONST SCALE    = 4
+CONST WIN_W    = CANVAS_W * SCALE
+CONST WIN_H    = CANVAS_H * SCALE
+
+SCREEN _NEWIMAGE(WIN_W, WIN_H, 32)
+_TITLE "HW Tooltip Reblit Test (1/2/3 modes, ESC quit)"
+
+DIM canvas AS LONG : canvas = _NEWIMAGE(CANVAS_W, CANVAS_H, 32)
+DIM hw     AS LONG : hw = 0
+DIM mode   AS INTEGER : mode = 1
+DIM frame  AS LONG : frame = 0
+DIM tipX   AS INTEGER : tipX = 40
+DIM dir    AS INTEGER : dir = 1
+DIM k      AS LONG
+
+' Tooltip size (mimics DRAW's tooltip dimensions roughly)
+CONST TT_W = 50
+CONST TT_H = 14
+
+DO
+    frame = frame + 1
+    k = _KEYHIT
+    IF k = 27 THEN EXIT DO
+    IF k = ASC("1") THEN mode = 1
+    IF k = ASC("2") THEN mode = 2
+    IF k = ASC("3") THEN mode = 3
+
+    ' Tooltip moves left-right
+    tipX = tipX + dir
+    IF tipX < 20 OR tipX > CANVAS_W - TT_W - 20 THEN dir = -dir
+
+    DIM tipY AS INTEGER : tipY = 40
+
+    ' === Render scene + tooltip to software canvas ===
+    _DEST canvas
+    _DONTBLEND canvas
+    CLS , _RGBA32(20, 30, 50, 255)  ' dark background (the "canvas content")
+    _BLEND canvas
+
+    ' Draw some background detail (so we can see if anything bleeds through)
+    DIM sx AS INTEGER, sy AS INTEGER
+    FOR sx = 0 TO CANVAS_W - 1 STEP 20
+        LINE (sx, 0)-(sx, CANVAS_H - 1), _RGB32(40, 50, 70)
+    NEXT sx
+    FOR sy = 0 TO CANVAS_H - 1 STEP 20
+        LINE (0, sy)-(CANVAS_W - 1, sy), _RGB32(40, 50, 70)
+    NEXT sy
+
+    ' Draw tooltip background + border + striped content
+    LINE (tipX, tipY)-(tipX + TT_W - 1, tipY + TT_H - 1), _RGB32(40, 40, 50), BF
+    LINE (tipX, tipY)-(tipX + TT_W - 1, tipY + TT_H - 1), _RGB32(120, 120, 140), B
+    FOR sx = tipX + 2 TO tipX + TT_W - 3 STEP 2
+        LINE (sx, tipY + 3)-(sx, tipY + TT_H - 4), _RGB32(255, 255, 100)
+    NEXT sx
+
+    _PRINTSTRING (4, 4), "Mode " + LTRIM$(STR$(mode)) + " F=" + LTRIM$(STR$(frame))
+
+    ' === Step 1: full present (HW or CPU based on mode) ===
+    SELECT CASE mode
+        CASE 1, 3
+            IF hw < -1 THEN _FREEIMAGE hw
+            hw = _COPYIMAGE(canvas, 33)
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), hw, 0
+        CASE 2
+            _PUTIMAGE (0, 0)-(WIN_W - 1, WIN_H - 1), canvas, 0
+    END SELECT
+
+    ' === Step 2: a "floating panel" draws directly to screen 0,
+    '   overlapping the tooltip area (mimics COLORMIXER_render behavior) ===
+    DIM panelX1 AS LONG, panelY1 AS LONG, panelX2 AS LONG, panelY2 AS LONG
+    panelX1 = (CANVAS_W \ 2) * SCALE
+    panelY1 = 0
+    panelX2 = WIN_W - 1
+    panelY2 = (TT_H + 60) * SCALE
+    _DEST 0
+    LINE (panelX1, panelY1)-(panelX2, panelY2), _RGB32(100, 50, 50), BF
+    _PRINTSTRING (panelX1 + 8, panelY1 + 8), "FLOATING PANEL"
+    _DEST canvas
+
+    ' === Step 3: CPU re-blit of tooltip rect (mimics TOOLTIP_reblit_to_screen0) ===
+    IF mode = 1 OR mode = 2 THEN
+        DIM srcX1 AS INTEGER, srcY1 AS INTEGER, srcX2 AS INTEGER, srcY2 AS INTEGER
+        srcX1 = tipX
+        srcY1 = tipY
+        srcX2 = tipX + TT_W - 1
+        srcY2 = tipY + TT_H - 1
+        DIM dstX1 AS LONG, dstY1 AS LONG, dstX2 AS LONG, dstY2 AS LONG
+        dstX1 = CLNG(srcX1) * SCALE
+        dstY1 = CLNG(srcY1) * SCALE
+        dstX2 = (CLNG(srcX1) + CLNG(TT_W)) * SCALE - 1
+        dstY2 = (CLNG(srcY1) + CLNG(TT_H)) * SCALE - 1
+        _PUTIMAGE (dstX1, dstY1)-(dstX2, dstY2), canvas, 0, (srcX1, srcY1)-(srcX2, srcY2)
+    END IF
+
+    _DISPLAY
+    _LIMIT 60
+LOOP
+
+IF hw < -1 THEN _FREEIMAGE hw
+_FREEIMAGE canvas
+SYSTEM

--- a/EXPERIMENTS/SETALPHA_VERIFY_TEST.BAS
+++ b/EXPERIMENTS/SETALPHA_VERIFY_TEST.BAS
@@ -1,0 +1,65 @@
+''
+' SETALPHA Verify Test — does _SETALPHA actually fix alpha-0 holes
+' caused by _RGBA32(...,240) draws with _BLEND on?
+'
+$CONSOLE
+
+SCREEN _NEWIMAGE(400, 200, 32)
+
+DIM img AS LONG : img = _NEWIMAGE(100, 100, 32)
+_DEST img
+_BLEND img
+CLS , _RGBA32(255, 255, 255, 255)
+LINE (10, 10)-(70, 70), _RGBA32(255, 0, 0, 240), BF
+
+DIM px AS _UNSIGNED LONG : px = POINT(30, 30)
+DIM aBefore AS LONG : aBefore = _ALPHA32(px)
+DIM rBefore AS LONG : rBefore = _RED32(px)
+DIM gBefore AS LONG : gBefore = _GREEN32(px)
+DIM bBefore AS LONG : bBefore = _BLUE32(px)
+
+' Now apply _SETALPHA 255 to the whole image (correct syntax — no middle param)
+_SETALPHA 255, img
+
+px = POINT(30, 30)
+DIM aAfter AS LONG : aAfter = _ALPHA32(px)
+DIM rAfter AS LONG : rAfter = _RED32(px)
+DIM gAfter AS LONG : gAfter = _GREEN32(px)
+DIM bAfter AS LONG : bAfter = _BLUE32(px)
+
+_DEST 0
+CLS , _RGB32(0, 0, 0)
+COLOR _RGB32(255, 255, 255)
+PRINT
+PRINT " Pixel (30, 30) of LINE BF _RGBA32(255,0,0,240) on opaque white canvas:"
+PRINT
+PRINT "   Before _SETALPHA 255:"
+PRINT "     RGBA = "; rBefore; ","; gBefore; ","; bBefore; ","; aBefore
+PRINT
+PRINT "   After _SETALPHA 255:"
+PRINT "     RGBA = "; rAfter; ","; gAfter; ","; bAfter; ","; aAfter
+PRINT
+IF aAfter = 255 THEN
+    COLOR _RGB32(0, 255, 0)
+    PRINT " _SETALPHA worked: alpha is now 255."
+    IF rAfter > 0 OR gAfter > 0 OR bAfter > 0 THEN
+        PRINT " Pixel HAS color data — _SETALPHA didn't wipe color."
+    ELSE
+        PRINT " Pixel is BLACK — _SETALPHA might have wiped color."
+    END IF
+ELSE
+    COLOR _RGB32(255, 100, 100)
+    PRINT " _SETALPHA did NOT fix alpha. Alpha after is "; aAfter
+END IF
+PRINT
+COLOR _RGB32(200, 200, 200)
+PRINT " Press any key to exit."
+
+DIM k AS LONG
+DO
+    k = _KEYHIT
+    _LIMIT 30
+LOOP UNTIL k > 0
+
+_FREEIMAGE img
+SYSTEM

--- a/GUI/GRID.BI
+++ b/GUI/GRID.BI
@@ -20,21 +20,33 @@ CONST GRID_MODE_HEX       = 3 ' Hexagonal grid
 CONST GRID_MODE_COUNT     = 4 ' Total number of modes (for cycling)
 
 TYPE DRAW_GRID
-    imgWidth   AS INTEGER        ' Width of the full grid image
-    imgHeight  AS INTEGER        ' Height of the full grid image
-    fgColor    AS _UNSIGNED LONG ' Foreground color of the grid lines
-    xPos       AS INTEGER        ' X position of the grid in the image
-    yPos       AS INTEGER        ' Y position of the grid in the image
-    gridWidth  AS INTEGER        ' Width of a grid square
-    gridHeight AS INTEGER        ' Height of a grid square
-    hStyle     AS INTEGER        ' Horizontal style &B0000111100001111 (16 bits)
-    vStyle     AS INTEGER        ' Vertical style &B0000111100001111 (16 bits)
-    imgHandle  AS LONG           ' Grid image handle
-    SHOW       AS INTEGER        ' Whether grid is visible (TRUE/FALSE)
-    SNAP       AS INTEGER        ' Whether snap-to-grid is enabled (TRUE/FALSE)
-    ALIGN_MODE AS INTEGER        ' Alignment mode : GRID_ALIGN_CORNER or GRID_ALIGN_CENTER
-    GRID_MODE  AS INTEGER        ' Geometry mode  : GRID_MODE_SQUARE/DIAGONAL/ISOMETRIC/HEX
-    CELL_FILL  AS INTEGER        ' Cell fill mode : fill tool fills grid cells instead of flood fill
+    imgWidth        AS INTEGER        ' Width of the full grid image
+    imgHeight       AS INTEGER        ' Height of the full grid image
+    fgColor         AS _UNSIGNED LONG ' Foreground color of the grid lines
+    xPos            AS INTEGER        ' X position of the grid in the image
+    yPos            AS INTEGER        ' Y position of the grid in the image
+    gridWidth       AS INTEGER        ' Width of a grid square
+    gridHeight      AS INTEGER        ' Height of a grid square
+    hStyle          AS INTEGER        ' Horizontal style &B0000111100001111 (16 bits)
+    vStyle          AS INTEGER        ' Vertical style &B0000111100001111 (16 bits)
+    imgHandle       AS LONG           ' Grid image handle (canvas-resolution)
+    SHOW            AS INTEGER        ' Whether grid is visible (TRUE/FALSE)
+    SNAP            AS INTEGER        ' Whether snap-to-grid is enabled (TRUE/FALSE)
+    ALIGN_MODE      AS INTEGER        ' Alignment mode : GRID_ALIGN_CORNER or GRID_ALIGN_CENTER
+    GRID_MODE       AS INTEGER        ' Geometry mode  : GRID_MODE_SQUARE/DIAGONAL/ISOMETRIC/HEX
+    CELL_FILL       AS INTEGER        ' Cell fill mode : fill tool fills grid cells instead of flood fill
+    ' Screen-space cache for axis-aligned square grid at zoom < 1.0 (avoids
+    ' per-frame LINE loop in RENDER_grids; rebuilt only when zoom / dimensions
+    ' / step / offset / color / opacity change).
+    ssCacheImg      AS LONG           ' Screen-space grid cache image handle
+    ssCacheW        AS INTEGER        ' Cache width (= zw at build time)
+    ssCacheH        AS INTEGER        ' Cache height (= zh at build time)
+    ssCacheZoom     AS SINGLE         ' Zoom at last cache build
+    ssCacheColor    AS _UNSIGNED LONG ' Color (with alpha) at last cache build
+    ssCacheStepX    AS INTEGER        ' Grid step X (canvas pixels) at last build
+    ssCacheStepY    AS INTEGER        ' Grid step Y (canvas pixels) at last build
+    ssCacheOffsetX  AS INTEGER        ' Grid offset X (canvas pixels) at last build
+    ssCacheOffsetY  AS INTEGER        ' Grid offset Y (canvas pixels) at last build
 END TYPE
 
 ' Pixel grid (checkerboard) for high zoom levels

--- a/GUI/GRID.BM
+++ b/GUI/GRID.BM
@@ -52,7 +52,19 @@ SUB GRID_init ()
     GRID.ALIGN_MODE% = preserveAlignMode%                             ' Preserve alignment mode
     GRID.GRID_MODE%  = CFG.GRID_MODE%                                 ' Grid mode from config (0=square default)
     GRID.CELL_FILL%  = (CFG.GRID_CELL_FILL% <> 0)                     ' Cell fill mode from config
-    
+
+    ' Screen-space cache starts empty; RENDER_grids builds on first use
+    IF GRID.ssCacheImg& < -1 THEN _FREEIMAGE GRID.ssCacheImg&
+    GRID.ssCacheImg&     = 0
+    GRID.ssCacheW%       = 0
+    GRID.ssCacheH%       = 0
+    GRID.ssCacheZoom!    = 0
+    GRID.ssCacheColor~&  = 0
+    GRID.ssCacheStepX%   = 0
+    GRID.ssCacheStepY%   = 0
+    GRID.ssCacheOffsetX% = 0
+    GRID.ssCacheOffsetY% = 0
+
     ' Draw the grid image once
     GRID_draw
 END SUB

--- a/GUI/GRID.BM
+++ b/GUI/GRID.BM
@@ -560,39 +560,19 @@ END SUB
 
 
 ''
-' Initialize the pixel grid (checkerboard for high zoom levels)
+' Initialize the pixel grid state (SHOW flag + colors).  The actual rendering
+' happens in RENDER_grids (SCREEN.BM) via a screen-space cache (PG_CACHE_IMG&)
+' or inline draw at extreme zoom — neither uses PIXEL_GRID.imgHandle&, so we
+' no longer allocate a canvas-resolution image here.
 '
 SUB PIXEL_GRID_init ()
+    ' Defensive: free any handle from a previous PIXEL_GRID_init that did
+    ' allocate (older builds).  No-op on a fresh session.
     IF PIXEL_GRID.imgHandle& < -1 THEN _FREEIMAGE PIXEL_GRID.imgHandle&
+    PIXEL_GRID.imgHandle& = 0
     PIXEL_GRID.SHOW%      = TRUE ' Enabled by default (auto-shows at 400%+ zoom)
     PIXEL_GRID.color1~&   = THEME.PIXEL_GRID_color1~&
     PIXEL_GRID.color2~&   = THEME.PIXEL_GRID_color2~&
-    PIXEL_GRID.imgHandle& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
-    PIXEL_GRID_draw
-END SUB
-
-
-''
-' Draw the pixel grid - single pixel lines around each pixel
-'
-SUB PIXEL_GRID_draw ()
-    DIM AS INTEGER x, y
-    DIM oldDest AS LONG
-    oldDest& = _DEST
-    _DEST PIXEL_GRID.imgHandle&
-    CLS , _RGBA32(0, 0, 0, 0) ' Clear with transparency
-    
-    ' Draw vertical lines (at each x position)
-    FOR x% = 0 TO SCRN.canvasW& - 1
-        LINE (x%, 0)-(x%, SCRN.canvasH& - 1), PIXEL_GRID.color1~&
-    NEXT x%
-    
-    ' Draw horizontal lines (at each y position)
-    FOR y% = 0 TO SCRN.canvasH& - 1
-        LINE (0, y%)-(SCRN.canvasW& - 1, y%), PIXEL_GRID.color1~&
-    NEXT y%
-    
-    _DEST oldDest&
 END SUB
 
 

--- a/GUI/PREVIEW.BM
+++ b/GUI/PREVIEW.BM
@@ -467,8 +467,15 @@ SUB PREVIEW_render (destHandle AS LONG)
             pvHasSource% = FALSE
         END IF
     ELSE
-        IF COMPOSITE_BUFFER& < -1 THEN
-            pvSrcImg&    = COMPOSITE_BUFFER&
+        ' Read from CANVAS_CONTENT_SRC& — set by RENDER_layers to either
+        ' COMPOSITE_BUFFER& (when the composite path runs) or the visible
+        ' layer's imgHandle& (trivial single-layer fast path).  Falls back to
+        ' COMPOSITE_BUFFER& if the new path hasn't run yet this session.
+        DIM pvSrcCandidate AS LONG
+        pvSrcCandidate& = CANVAS_CONTENT_SRC&
+        IF pvSrcCandidate& >= -1 THEN pvSrcCandidate& = COMPOSITE_BUFFER&
+        IF pvSrcCandidate& < -1 THEN
+            pvSrcImg&    = pvSrcCandidate&
             pvSrcW&      = SCRN.canvasW&
             pvSrcH&      = SCRN.canvasH&
             pvHasSource% = TRUE
@@ -1424,8 +1431,13 @@ SUB PREVIEW_pick_color_at (rawX AS INTEGER, rawY AS INTEGER, button AS INTEGER)
         pcSrcW&   = PREVIEW.floatImageW%
         pcSrcH&   = PREVIEW.floatImageH%
     ELSE
-        IF COMPOSITE_BUFFER& >= -1 THEN EXIT SUB
-        pcSrcImg& = COMPOSITE_BUFFER&
+        ' Pull from CANVAS_CONTENT_SRC& (set by RENDER_layers); fall back to
+        ' COMPOSITE_BUFFER& if not set yet.
+        DIM pcSrcCandidate AS LONG
+        pcSrcCandidate& = CANVAS_CONTENT_SRC&
+        IF pcSrcCandidate& >= -1 THEN pcSrcCandidate& = COMPOSITE_BUFFER&
+        IF pcSrcCandidate& >= -1 THEN EXIT SUB
+        pcSrcImg& = pcSrcCandidate&
         pcSrcW&   = SCRN.canvasW&
         pcSrcH&   = SCRN.canvasH&
     END IF
@@ -1538,8 +1550,13 @@ SUB PREVIEW_render_loupe (dest AS LONG)
         plSrcW&   = PREVIEW.floatImageW%
         plSrcH&   = PREVIEW.floatImageH%
     ELSE
-        IF COMPOSITE_BUFFER& >= -1 THEN EXIT SUB
-        plSrcImg& = COMPOSITE_BUFFER&
+        ' Pull from CANVAS_CONTENT_SRC& (set by RENDER_layers); fall back to
+        ' COMPOSITE_BUFFER& if not set yet.
+        DIM plSrcCandidate AS LONG
+        plSrcCandidate& = CANVAS_CONTENT_SRC&
+        IF plSrcCandidate& >= -1 THEN plSrcCandidate& = COMPOSITE_BUFFER&
+        IF plSrcCandidate& >= -1 THEN EXIT SUB
+        plSrcImg& = plSrcCandidate&
         plSrcW&   = SCRN.canvasW&
         plSrcH&   = SCRN.canvasH&
     END IF

--- a/GUI/TRANSPARENCY.BI
+++ b/GUI/TRANSPARENCY.BI
@@ -8,14 +8,17 @@
 $INCLUDEONCE
 
 TYPE TRANSPARENCY_OBJ
-    imgHandle  AS LONG           ' Cached checkerboard image
-    imgWidth   AS INTEGER        ' Cached image dimensions
-    imgHeight  AS INTEGER
-    checkSizeX AS INTEGER        ' Width of each checker square
-    checkSizeY AS INTEGER        ' Height of each checker square
-    color1     AS _UNSIGNED LONG ' Light checker color
-    color2     AS _UNSIGNED LONG ' Dark checker color
-    lastZoom   AS SINGLE         ' Zoom level when cache was built
+    imgHandle    AS LONG           ' Display-rect blit cache (rebuilt on zoom change via scaled _PUTIMAGE from blueprint)
+    imgWidth     AS INTEGER        ' Display-rect cache dimensions
+    imgHeight    AS INTEGER
+    blueprint    AS LONG           ' Canvas-resolution ground-truth pattern (zoom-independent, built once via LINE BF)
+    blueprintW   AS INTEGER        ' Blueprint dimensions
+    blueprintH   AS INTEGER
+    checkSizeX   AS INTEGER        ' Width of each checker square
+    checkSizeY   AS INTEGER        ' Height of each checker square
+    color1       AS _UNSIGNED LONG ' Light checker color
+    color2       AS _UNSIGNED LONG ' Dark checker color
+    lastZoom     AS SINGLE         ' Zoom level when display cache was last built
 END TYPE
 
 DIM SHARED TRANSPARENCY AS TRANSPARENCY_OBJ

--- a/GUI/TRANSPARENCY.BM
+++ b/GUI/TRANSPARENCY.BM
@@ -3,18 +3,31 @@
 ' =============================================================================
 ' Transparency checkerboard background rendering.
 '
+' Two-level cache:
+'   - blueprint  : canvas-resolution ground truth, rebuilt only when colors /
+'                  check-size / canvas size change (LINE BF loop, expensive)
+'   - imgHandle  : display-rect blit cache, rebuilt from blueprint via one
+'                  scaled _PUTIMAGE when zoom or dimensions change (cheap)
+'   - per frame  : no-scale _PUTIMAGE blit of imgHandle to target (memcpy)
+'
+' This gives the win in both directions: rapid zoom scrubbing doesn't
+' re-run the LINE loop, and per-frame draw is never a scaled blit.
+'
 ' @author Rick Christy <grymmjack@gmail.com>
 '
 $INCLUDEONCE
 
 ''
 ' Initialize the transparency checkerboard system
-' 
+'
 SUB TRANSPARENCY_init ()
     DIM effSizeX AS INTEGER, effSizeY AS INTEGER
-    TRANSPARENCY.imgHandle& = 0
-    TRANSPARENCY.imgWidth%  = 0
-    TRANSPARENCY.imgHeight% = 0
+    TRANSPARENCY.imgHandle&  = 0
+    TRANSPARENCY.imgWidth%   = 0
+    TRANSPARENCY.imgHeight%  = 0
+    TRANSPARENCY.blueprint&  = 0
+    TRANSPARENCY.blueprintW% = 0
+    TRANSPARENCY.blueprintH% = 0
     ' Resolve check sizes: config overrides theme (CFG 0 = use theme default)
     IF CFG.TRANSPARENCY_CHECK_SIZE_X% > 0 THEN
         effSizeX% = CFG.TRANSPARENCY_CHECK_SIZE_X%
@@ -36,33 +49,39 @@ END SUB
 
 ''
 ' Invalidate the cached checkerboard (call when size/colors change)
-' 
+'
 SUB TRANSPARENCY_invalidate ()
     IF TRANSPARENCY.imgHandle& < -1 THEN
         _FREEIMAGE TRANSPARENCY.imgHandle&
     END IF
-    TRANSPARENCY.imgHandle& = 0
-    TRANSPARENCY.imgWidth%  = 0
-    TRANSPARENCY.imgHeight% = 0
+    IF TRANSPARENCY.blueprint& < -1 THEN
+        _FREEIMAGE TRANSPARENCY.blueprint&
+    END IF
+    TRANSPARENCY.imgHandle&  = 0
+    TRANSPARENCY.imgWidth%   = 0
+    TRANSPARENCY.imgHeight%  = 0
+    TRANSPARENCY.blueprint&  = 0
+    TRANSPARENCY.blueprintW% = 0
+    TRANSPARENCY.blueprintH% = 0
 END SUB
 
 
 ''
 ' Render the transparency checkerboard to a target location.
-' Creates/updates cached image if needed.
+' Two-level cache (blueprint + display-rect blit cache); see file header.
 ' @param targetImg LONG Destination image handle to draw the checkerboard onto
 ' @param x INTEGER Left edge X coordinate on the target surface
 ' @param y INTEGER Top edge Y coordinate on the target surface
 ' @param w INTEGER Width of the area to fill with checkerboard
 ' @param h INTEGER Height of the area to fill with checkerboard
-' 
+'
 SUB TRANSPARENCY_render (targetImg AS LONG, x AS INTEGER, y AS INTEGER, w AS INTEGER, h AS INTEGER)
     DIM oldDest     AS LONG
     DIM cx          AS INTEGER, cy AS INTEGER
     DIM checkX      AS INTEGER, checkY AS INTEGER
     DIM useColor    AS _UNSIGNED LONG
-    DIM scaledSizeX AS INTEGER, scaledSizeY AS INTEGER
     DIM effSizeX    AS INTEGER, effSizeY AS INTEGER
+    DIM bpW         AS INTEGER, bpH AS INTEGER
 
     IF w <= 0 OR h <= 0 THEN EXIT SUB
 
@@ -77,73 +96,117 @@ SUB TRANSPARENCY_render (targetImg AS LONG, x AS INTEGER, y AS INTEGER, w AS INT
     ELSE
         effSizeY% = THEME.TRANSPARENCY_check_size_y%
     END IF
-    
-    ' Scale checker size by zoom so squares grow/shrink with canvas
-    scaledSizeX% = INT(effSizeX% * SCRN.zoom!)
-    IF scaledSizeX% < 2 THEN scaledSizeX% = 2  ' Minimum 2px to stay visible
-    scaledSizeY% = INT(effSizeY% * SCRN.zoom!)
-    IF scaledSizeY% < 2 THEN scaledSizeY% = 2
-    
-    ' Check if we need to recreate the cached image
-    IF TRANSPARENCY.imgHandle& = 0 OR _
-       TRANSPARENCY.imgWidth% <> w% OR _
-       TRANSPARENCY.imgHeight% <> h% OR _
+
+    ' === LEVEL 1: Build canvas-resolution blueprint (rare rebuild) ===
+    bpW% = SCRN.canvasW&
+    bpH% = SCRN.canvasH&
+    IF bpW% < 1 THEN bpW% = w%
+    IF bpH% < 1 THEN bpH% = h%
+
+    IF TRANSPARENCY.blueprint& = 0 OR _
+       TRANSPARENCY.blueprintW% <> bpW% OR _
+       TRANSPARENCY.blueprintH% <> bpH% OR _
        TRANSPARENCY.checkSizeX% <> effSizeX% OR _
        TRANSPARENCY.checkSizeY% <> effSizeY% OR _
        TRANSPARENCY.color1~& <> CFG.TRANSPARENCY_CHECK_COLOR1~& OR _
-       TRANSPARENCY.color2~& <> CFG.TRANSPARENCY_CHECK_COLOR2~& OR _
-       TRANSPARENCY.lastZoom! <> SCRN.zoom! THEN
-        
-        ' Free old image if exists
-        IF TRANSPARENCY.imgHandle& < -1 THEN
-            _FREEIMAGE TRANSPARENCY.imgHandle&
-        END IF
-        
-        ' Create new cached image
-        TRANSPARENCY.imgHandle&  = _NEWIMAGE(w%, h%, 32)
-        TRANSPARENCY.imgWidth%   = w%
-        TRANSPARENCY.imgHeight%  = h%
+       TRANSPARENCY.color2~& <> CFG.TRANSPARENCY_CHECK_COLOR2~& THEN
+
+        IF TRANSPARENCY.blueprint& < -1 THEN _FREEIMAGE TRANSPARENCY.blueprint&
+        TRANSPARENCY.blueprint&  = _NEWIMAGE(bpW%, bpH%, 32)
+        TRANSPARENCY.blueprintW% = bpW%
+        TRANSPARENCY.blueprintH% = bpH%
         TRANSPARENCY.checkSizeX% = effSizeX%
         TRANSPARENCY.checkSizeY% = effSizeY%
         TRANSPARENCY.color1~&    = CFG.TRANSPARENCY_CHECK_COLOR1~&
         TRANSPARENCY.color2~&    = CFG.TRANSPARENCY_CHECK_COLOR2~&
-        TRANSPARENCY.lastZoom!   = SCRN.zoom!
-        
-        ' Draw the checkerboard pattern (scaled by zoom)
+
+        ' Draw the checkerboard pattern at canvas resolution (one-time cost)
         oldDest& = _DEST
-        _DEST TRANSPARENCY.imgHandle&
-        
-        FOR cy% = 0 TO h% - 1 STEP scaledSizeY%
-            checkY% = cy% \ scaledSizeY%
-            FOR cx% = 0 TO w% - 1 STEP scaledSizeX%
-                checkX% = cx% \ scaledSizeX%
-                
-                ' Alternate colors based on position
+        _DEST TRANSPARENCY.blueprint&
+
+        FOR cy% = 0 TO bpH% - 1 STEP effSizeY%
+            checkY% = cy% \ effSizeY%
+            FOR cx% = 0 TO bpW% - 1 STEP effSizeX%
+                checkX% = cx% \ effSizeX%
+
                 IF ((checkX% + checkY%) MOD 2) = 0 THEN
                     useColor~& = TRANSPARENCY.color1~&
                 ELSE
                     useColor~& = TRANSPARENCY.color2~&
                 END IF
-                
-                ' Draw the checker rectangle
+
                 DIM x2 AS INTEGER, y2 AS INTEGER
-                x2% = cx% + scaledSizeX% - 1
-                y2% = cy% + scaledSizeY% - 1
-                IF x2% >= w% THEN x2% = w% - 1
-                IF y2% >= h% THEN y2% = h% - 1
-                
+                x2% = cx% + effSizeX% - 1
+                y2% = cy% + effSizeY% - 1
+                IF x2% >= bpW% THEN x2% = bpW% - 1
+                IF y2% >= bpH% THEN y2% = bpH% - 1
+
                 LINE (cx%, cy%)-(x2%, y2%), useColor~&, BF
             NEXT cx%
         NEXT cy%
-        
+
+        _DEST oldDest&
+
+        ' Blueprint changed — display cache must be rebuilt from it
+        IF TRANSPARENCY.imgHandle& < -1 THEN _FREEIMAGE TRANSPARENCY.imgHandle&
+        TRANSPARENCY.imgHandle& = 0
+        TRANSPARENCY.imgWidth%  = 0
+        TRANSPARENCY.imgHeight% = 0
+        TRANSPARENCY.lastZoom!  = 0
+    END IF
+
+    ' === LEVEL 2: Build display-rect blit cache from blueprint (per zoom) ===
+    ' Only when the display rect fits in the viewport.  At deep zoom-in,
+    ' (zw, zh) can be many times viewport size — building a 530MB cache
+    ' (zoom 8x on a 1920x1080 canvas) is catastrophic.  Fall back to a
+    ' direct scaled blit from the blueprint; _PUTIMAGE clips at dst bounds,
+    ' so the per-frame cost stays proportional to the *visible* area
+    ' regardless of how huge the display rect is.
+    DIM cacheFitsViewport AS INTEGER
+    cacheFitsViewport% = (w% <= SCRN.w& AND h% <= SCRN.h&)
+
+    IF cacheFitsViewport% THEN
+        IF TRANSPARENCY.imgHandle& = 0 OR _
+           TRANSPARENCY.imgWidth% <> w% OR _
+           TRANSPARENCY.imgHeight% <> h% THEN
+
+            IF TRANSPARENCY.imgHandle& < -1 THEN _FREEIMAGE TRANSPARENCY.imgHandle&
+            TRANSPARENCY.imgHandle& = _NEWIMAGE(w%, h%, 32)
+            TRANSPARENCY.imgWidth%  = w%
+            TRANSPARENCY.imgHeight% = h%
+            TRANSPARENCY.lastZoom!  = SCRN.zoom!
+
+            ' Single scaled blit: blueprint -> display cache
+            oldDest& = _DEST
+            _DEST TRANSPARENCY.imgHandle&
+            _DONTBLEND TRANSPARENCY.imgHandle&
+            _PUTIMAGE (0, 0)-(w% - 1, h% - 1), TRANSPARENCY.blueprint&
+            _BLEND TRANSPARENCY.imgHandle&
+            _DEST oldDest&
+        END IF
+
+        ' Per-frame: no-scale blit display cache to target (memcpy)
+        oldDest& = _DEST
+        _DEST targetImg&
+        _DONTBLEND targetImg& ' No blending for background
+        _PUTIMAGE (x%, y%), TRANSPARENCY.imgHandle&
+        _BLEND targetImg&     ' Re-enable blending for subsequent operations
+        _DEST oldDest&
+    ELSE
+        ' Display rect exceeds viewport — direct scaled blit, no cache.
+        ' Free any stale cache so memory doesn't bloat from a previous
+        ' fits-viewport zoom level.
+        IF TRANSPARENCY.imgHandle& < -1 THEN _FREEIMAGE TRANSPARENCY.imgHandle&
+        TRANSPARENCY.imgHandle& = 0
+        TRANSPARENCY.imgWidth%  = 0
+        TRANSPARENCY.imgHeight% = 0
+        TRANSPARENCY.lastZoom!  = 0
+
+        oldDest& = _DEST
+        _DEST targetImg&
+        _DONTBLEND targetImg&
+        _PUTIMAGE (x%, y%)-(x% + w - 1, y% + h - 1), TRANSPARENCY.blueprint&
+        _BLEND targetImg&
         _DEST oldDest&
     END IF
-    
-    ' Blit the cached checkerboard to target
-    oldDest& = _DEST
-    _DEST targetImg&
-    _DONTBLEND targetImg& ' No blending for background
-    _PUTIMAGE (x%, y%), TRANSPARENCY.imgHandle&
-    _BLEND targetImg&     ' Re-enable blending for subsequent operations
-    _DEST oldDest&
 END SUB

--- a/OUTPUT/SCREEN.BI
+++ b/OUTPUT/SCREEN.BI
@@ -119,6 +119,16 @@ DIM SHARED SCENE_CACHE AS LONG                 ' Cached pre-cursor canvas image
 DIM SHARED SCENE_DIRTY AS INTEGER              ' TRUE = must do full repaint
 SCENE_DIRTY% = TRUE                            ' Start dirty
 
+' Canonical "current canvas content" image handle.  Set by RENDER_layers to:
+'  - COMPOSITE_BUFFER& when the composite path is used (multiple layers,
+'    blend modes, opacity < 100%, etc.)
+'  - the visible layer's imgHandle& directly in the trivial single-layer case,
+'    avoiding the 8MB canvas-resolution memcpy each frame
+' PREVIEW reads from this instead of COMPOSITE_BUFFER& so it works in both
+' modes.  0 = not yet set (preview falls back to old behavior).
+DIM SHARED CANVAS_CONTENT_SRC AS LONG
+CANVAS_CONTENT_SRC& = 0
+
 DIM SHARED GRAYSCALE_PREVIEW_ACTIVE AS INTEGER ' TRUE = apply grayscale filter to final output
 GRAYSCALE_PREVIEW_ACTIVE% = FALSE
 

--- a/OUTPUT/SCREEN.BI
+++ b/OUTPUT/SCREEN.BI
@@ -15,6 +15,7 @@ TYPE SCREEN_OBJ
     canvasH                       AS LONG    ' Actual artwork/canvas height (may be smaller than h)
     bpp                           AS INTEGER
     CANVAS                        AS LONG
+    CANVAS_HW                     AS LONG    ' Hardware-image (mode 33) twin of CANVAS for GPU final blit
     PAINTING                      AS LONG
     CURSOR                        AS LONG
     GUI                           AS LONG

--- a/OUTPUT/SCREEN.BI
+++ b/OUTPUT/SCREEN.BI
@@ -15,7 +15,6 @@ TYPE SCREEN_OBJ
     canvasH                       AS LONG    ' Actual artwork/canvas height (may be smaller than h)
     bpp                           AS INTEGER
     CANVAS                        AS LONG
-    CANVAS_HW                     AS LONG    ' Hardware-image (mode 33) twin of CANVAS for GPU final blit
     PAINTING                      AS LONG
     CURSOR                        AS LONG
     GUI                           AS LONG

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -804,6 +804,44 @@ SUB RENDER_layers (dx AS INTEGER, dy AS INTEGER, zw AS LONG, zh AS LONG)
         ' Rebuild render order lookup table if dirty
         IF RENDER_ORDER_DIRTY% THEN RENDER_ORDER_rebuild
 
+        ' === Trivial single-layer fast path ===
+        ' When the only reason useComposite is TRUE is PREVIEW visibility and
+        ' the scene is exactly one visible non-group layer with full opacity,
+        ' NORMAL blend, no apron, no move-preview, we can skip the composite
+        ' buffer entirely.  The "composite" is just a copy of that one layer,
+        ' so we point CANVAS_CONTENT_SRC at the layer directly and let the
+        ' non-composite blit path draw it.  Saves an 8MB canvas-res memcpy
+        ' every dirty frame on the most common drawing workflow.
+        DIM trivialOnlyLayer    AS INTEGER
+        DIM trivialVisibleCount AS INTEGER
+        trivialOnlyLayer%    = 0
+        trivialVisibleCount% = 0
+        IF useComposite% AND NOT BLEND_needs_composite% AND NOT BLEND_HAS_ISOLATED_GROUPS% AND NOT MOVE.ACTIVE THEN
+            DIM trivI AS INTEGER, trivLayer AS INTEGER
+            FOR trivI% = 1 TO RENDER_ORDER_COUNT%
+                trivLayer% = RENDER_ORDER%(trivI%)
+                IF trivLayer% > 0 THEN
+                    IF LAYERS(trivLayer%).visible% AND LAYERS(trivLayer%).layerType% <> LAYER_TYPE_GROUP THEN
+                        ' Bail if this visible layer disqualifies the trivial path
+                        IF LAYERS(trivLayer%).opacity% <> 255 _
+                           OR LAYERS(trivLayer%).blendMode% <> BLEND_NORMAL _
+                           OR LAYERS(trivLayer%).apronW% <> 0 _
+                           OR LAYERS(trivLayer%).apronH% <> 0 THEN
+                            trivialVisibleCount% = 99
+                            EXIT FOR
+                        END IF
+                        trivialVisibleCount% = trivialVisibleCount% + 1
+                        trivialOnlyLayer%    = trivLayer%
+                        IF trivialVisibleCount% > 1 THEN EXIT FOR
+                    END IF
+                END IF
+            NEXT trivI%
+            IF trivialVisibleCount% = 1 THEN
+                useComposite% = FALSE                                  ' Take the fast direct-blit path
+                CANVAS_CONTENT_SRC& = LAYERS(trivialOnlyLayer%).imgHandle& ' Where PREVIEW reads from
+            END IF
+        END IF
+
         ' Start index for layer loop (1 = full composite, >1 = partial cache hit)
         DIM compositeStartIdx AS INTEGER
         DIM savePartialCache  AS INTEGER
@@ -1305,6 +1343,7 @@ SUB RENDER_layers (dx AS INTEGER, dy AS INTEGER, zw AS LONG, zh AS LONG)
         IF useComposite% THEN
             _PUTIMAGE (dx%, dy%)-(dx% + zw& - 1, dy% + zh& - 1), compositeImg&, SCRN.CANVAS&
             ' compositeImg& is persistent (COMPOSITE_BUFFER&), do NOT free it
+            CANVAS_CONTENT_SRC& = compositeImg&  ' Where PREVIEW reads from
 
             ' Save completed composite for next frame's region-based path.
             ' The cache feeds the region path (line ~828), which only triggers

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -3182,18 +3182,12 @@ SUB SCREEN_render ()
             PERF_stop PERF_FULL_GRIDS
         END IF
 
-        ' Symmetry guides — center tile only
+        ' Symmetry guides — center tile only.  Drawn directly into SCRN.CANVAS
+        ' (LINE clips at dst bounds); no intermediate display-rect image, which
+        ' would balloon to 8.5 GB at zoom 32x on a 1920x1080 canvas.
         PERF_start PERF_FULL_SYMMETRY
         IF SYMMETRY.MODE > 0 THEN
-            IF SYMMETRY.imgHandle& = 0 OR _WIDTH(SYMMETRY.imgHandle&) <> zw& OR _HEIGHT(SYMMETRY.imgHandle&) <> zh& THEN
-                IF SYMMETRY.imgHandle& < -1 THEN _FREEIMAGE SYMMETRY.imgHandle&
-                SYMMETRY.imgHandle& = _NEWIMAGE(zw&, zh&, 32)
-                SYMMETRY.DIRTY%     = TRUE
-            END IF
-            SYMMETRY_render_guides zw&, zh&, SCRN.zoom!
-            _DEST SCRN.CANVAS&
-            _BLEND SCRN.CANVAS&
-            _PUTIMAGE (dx%, dy%), SYMMETRY.imgHandle&, SCRN.CANVAS&
+            SYMMETRY_render_guides SCRN.CANVAS&, dx%, dy%, zw&, zh&, SCRN.zoom!
         END IF
         PERF_stop PERF_FULL_SYMMETRY
 
@@ -3255,18 +3249,7 @@ SUB SCREEN_render ()
         ' Draw symmetry guide overlay (after grids, before border/GUI)
         PERF_start PERF_FULL_SYMMETRY
         IF SYMMETRY.MODE > 0 THEN
-            ' Recreate guide image if size changed
-            IF SYMMETRY.imgHandle& = 0 OR _WIDTH(SYMMETRY.imgHandle&) <> zw& OR _HEIGHT(SYMMETRY.imgHandle&) <> zh& THEN
-                IF SYMMETRY.imgHandle& < -1 THEN _FREEIMAGE SYMMETRY.imgHandle&
-                SYMMETRY.imgHandle& = _NEWIMAGE(zw&, zh&, 32)
-                SYMMETRY.DIRTY%     = TRUE
-            END IF
-
-            ' (Logging removed from render path for performance)
-            SYMMETRY_render_guides zw&, zh&, SCRN.zoom!
-            _DEST SCRN.CANVAS&
-            _BLEND SCRN.CANVAS&          ' Use alpha blending for transparency
-            _PUTIMAGE (dx%, dy%), SYMMETRY.imgHandle&, SCRN.CANVAS&
+            SYMMETRY_render_guides SCRN.CANVAS&, dx%, dy%, zw&, zh&, SCRN.zoom!
         END IF
         PERF_stop PERF_FULL_SYMMETRY
 

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -1298,21 +1298,33 @@ SUB RENDER_layers (dx AS INTEGER, dy AS INTEGER, zw AS LONG, zh AS LONG)
             _PUTIMAGE (dx%, dy%)-(dx% + zw& - 1, dy% + zh& - 1), compositeImg&, SCRN.CANVAS&
             ' compositeImg& is persistent (COMPOSITE_BUFFER&), do NOT free it
 
-            ' Save completed composite for next frame's region-based path
-            IF COMPOSITE_RESULT_CACHE& = 0 OR _
-               _WIDTH(COMPOSITE_RESULT_CACHE&) <> SCRN.canvasW& OR _
-               _HEIGHT(COMPOSITE_RESULT_CACHE&) <> SCRN.canvasH& THEN
-                IF COMPOSITE_RESULT_CACHE& < -1 THEN _FREEIMAGE COMPOSITE_RESULT_CACHE&
-                COMPOSITE_RESULT_CACHE& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
+            ' Save completed composite for next frame's region-based path.
+            ' The cache feeds the region path (line ~828), which only triggers
+            ' when BLEND_needs_composite% is TRUE.  When the composite was
+            ' only built to feed PREVIEW (which reads compositeImg& directly,
+            ' not the cache), skip the canvas-sized memcpy — at 1920x1080
+            ' that's ~8MB/frame of pure waste.
+            IF BLEND_needs_composite% THEN
+                IF COMPOSITE_RESULT_CACHE& = 0 OR _
+                   _WIDTH(COMPOSITE_RESULT_CACHE&) <> SCRN.canvasW& OR _
+                   _HEIGHT(COMPOSITE_RESULT_CACHE&) <> SCRN.canvasH& THEN
+                    IF COMPOSITE_RESULT_CACHE& < -1 THEN _FREEIMAGE COMPOSITE_RESULT_CACHE&
+                    COMPOSITE_RESULT_CACHE& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
+                END IF
+                DIM crOldDest AS LONG
+                crOldDest& = _DEST
+                _DEST COMPOSITE_RESULT_CACHE&
+                _DONTBLEND COMPOSITE_RESULT_CACHE&
+                _PUTIMAGE , compositeImg&, COMPOSITE_RESULT_CACHE&
+                _BLEND COMPOSITE_RESULT_CACHE&
+                _DEST crOldDest&
+                COMPOSITE_RESULT_VALID% = TRUE
+            ELSE
+                ' Composite was built only for PREVIEW; the cache is stale
+                ' relative to next frame, so mark it invalid to prevent the
+                ' region path from using out-of-date data.
+                COMPOSITE_RESULT_VALID% = FALSE
             END IF
-            DIM crOldDest AS LONG
-            crOldDest& = _DEST
-            _DEST COMPOSITE_RESULT_CACHE&
-            _DONTBLEND COMPOSITE_RESULT_CACHE&
-            _PUTIMAGE , compositeImg&, COMPOSITE_RESULT_CACHE&
-            _BLEND COMPOSITE_RESULT_CACHE&
-            _DEST crOldDest&
-            COMPOSITE_RESULT_VALID% = TRUE
         END IF
     ELSE
         ' Fallback: Use SCRN.PAINTING if no layers exist yet (legacy support)
@@ -1370,22 +1382,86 @@ SUB RENDER_grids (dx AS INTEGER, dy AS INTEGER, zw AS LONG, zh AS LONG)
                     ssOpacity% = THEME.GRID_opacity%
                 END IF
                 ssColor~& = _RGBA32(_RED32(ssColor~&), _GREEN32(ssColor~&), _BLUE32(ssColor~&), ssOpacity%)
-                ' Vertical lines
-                DIM ssx       AS SINGLE : ssx! = dx% + GRID.xPos% * SCRN.zoom!
-                DO WHILE INT(ssx!) <= dx% + zw& - 1
-                    IF INT(ssx!) >= dx% THEN
-                        LINE (INT(ssx!), dy%)-(INT(ssx!), dy% + zh& - 1), ssColor~&
+
+                ' Screen-space cache: rebuild only when zoom / dimensions / step /
+                ' offset / colour changes; per-frame draw is a single _PUTIMAGE
+                ' memcpy.  At 1920x1080 zoom 0.25 this replaces ~375 LINE calls
+                ' per frame with one cached blit.
+                '
+                ' Defensive: skip caching when (zw, zh) exceeds viewport (e.g.
+                ' huge canvas at zoom just under 1.0).  Inline LINE-loop is used
+                ' instead; LINE clips to dest bounds so per-frame cost stays
+                ' proportional to visible area.
+                DIM gridCacheFits AS INTEGER
+                gridCacheFits% = (zw& <= SCRN.w& AND zh& <= SCRN.h&)
+
+                IF gridCacheFits% THEN
+                    IF GRID.ssCacheImg& = 0 OR _
+                       GRID.ssCacheW% <> zw& OR _
+                       GRID.ssCacheH% <> zh& OR _
+                       GRID.ssCacheZoom! <> SCRN.zoom! OR _
+                       GRID.ssCacheColor~& <> ssColor~& OR _
+                       GRID.ssCacheStepX% <> GRID.gridWidth% OR _
+                       GRID.ssCacheStepY% <> GRID.gridHeight% OR _
+                       GRID.ssCacheOffsetX% <> GRID.xPos% OR _
+                       GRID.ssCacheOffsetY% <> GRID.yPos% THEN
+                        IF GRID.ssCacheImg& < -1 THEN _FREEIMAGE GRID.ssCacheImg&
+                        GRID.ssCacheImg&     = _NEWIMAGE(zw&, zh&, 32)
+                        GRID.ssCacheW%       = zw&
+                        GRID.ssCacheH%       = zh&
+                        GRID.ssCacheZoom!    = SCRN.zoom!
+                        GRID.ssCacheColor~&  = ssColor~&
+                        GRID.ssCacheStepX%   = GRID.gridWidth%
+                        GRID.ssCacheStepY%   = GRID.gridHeight%
+                        GRID.ssCacheOffsetX% = GRID.xPos%
+                        GRID.ssCacheOffsetY% = GRID.yPos%
+
+                        DIM ssOldDest AS LONG : ssOldDest& = _DEST
+                        _DEST GRID.ssCacheImg&
+                        CLS , _RGBA32(0, 0, 0, 0)
+                        ' Vertical lines (cache-local coords; offset applied at blit time)
+                        DIM ssx AS SINGLE : ssx! = GRID.xPos% * SCRN.zoom!
+                        DO WHILE INT(ssx!) <= zw& - 1
+                            IF INT(ssx!) >= 0 THEN
+                                LINE (INT(ssx!), 0)-(INT(ssx!), zh& - 1), ssColor~&
+                            END IF
+                            ssx! = ssx! + ssStepX!
+                        LOOP
+                        ' Horizontal lines
+                        DIM ssy AS SINGLE : ssy! = GRID.yPos% * SCRN.zoom!
+                        DO WHILE INT(ssy!) <= zh& - 1
+                            IF INT(ssy!) >= 0 THEN
+                                LINE (0, INT(ssy!))-(zw& - 1, INT(ssy!)), ssColor~&
+                            END IF
+                            ssy! = ssy! + ssStepY!
+                        LOOP
+                        _DEST ssOldDest&
                     END IF
-                    ssx! = ssx! + ssStepX!
-                LOOP
-                ' Horizontal lines
-                DIM ssy       AS SINGLE : ssy! = dy% + GRID.yPos% * SCRN.zoom!
-                DO WHILE INT(ssy!) <= dy% + zh& - 1
-                    IF INT(ssy!) >= dy% THEN
-                        LINE (dx%, INT(ssy!))-(dx% + zw& - 1, INT(ssy!)), ssColor~&
-                    END IF
-                    ssy! = ssy! + ssStepY!
-                LOOP
+                    ' Per-frame: one blit (memcpy, no scaling)
+                    _PUTIMAGE (dx%, dy%), GRID.ssCacheImg&, SCRN.CANVAS&
+                ELSE
+                    ' Cache would exceed viewport — drop any stale cache,
+                    ' draw directly into SCRN.CANVAS (LINE clips at dst).
+                    IF GRID.ssCacheImg& < -1 THEN _FREEIMAGE GRID.ssCacheImg&
+                    GRID.ssCacheImg&  = 0
+                    GRID.ssCacheW%    = 0
+                    GRID.ssCacheH%    = 0
+                    GRID.ssCacheZoom! = 0
+                    DIM ssxFb AS SINGLE : ssxFb! = dx% + GRID.xPos% * SCRN.zoom!
+                    DO WHILE INT(ssxFb!) <= dx% + zw& - 1
+                        IF INT(ssxFb!) >= dx% THEN
+                            LINE (INT(ssxFb!), dy%)-(INT(ssxFb!), dy% + zh& - 1), ssColor~&
+                        END IF
+                        ssxFb! = ssxFb! + ssStepX!
+                    LOOP
+                    DIM ssyFb AS SINGLE : ssyFb! = dy% + GRID.yPos% * SCRN.zoom!
+                    DO WHILE INT(ssyFb!) <= dy% + zh& - 1
+                        IF INT(ssyFb!) >= dy% THEN
+                            LINE (dx%, INT(ssyFb!))-(dx% + zw& - 1, INT(ssyFb!)), ssColor~&
+                        END IF
+                        ssyFb! = ssyFb! + ssStepY!
+                    LOOP
+                END IF
             END IF
         ELSE
             ' Non-square / rotated grids, or zoom >= 100%: use cached image
@@ -1424,38 +1500,103 @@ SUB RENDER_grids (dx AS INTEGER, dy AS INTEGER, zw AS LONG, zh AS LONG)
             pgOpacity% = THEME.PIXEL_GRID_opacity%
         END IF
 
-        ' Reuse cached pixel grid image if zoom/size/color/opacity unchanged
-        IF PG_CACHE_IMG& = 0 OR _
-           PG_CACHE_ZW& <> zw& OR _
-           PG_CACHE_ZH& <> zh& OR _
-           PG_CACHE_ZOOM% <> pzoom% OR _
-           PG_CACHE_COLOR~& <> pgColor~& OR _
-           PG_CACHE_OPACITY% <> pgOpacity% THEN
-            ' Cache miss — rebuild pixel grid image
+        ' Defensive: skip the cache when the entire pixel grid wouldn't fit
+        ' in the viewport (e.g. zoom 32x on 1920x1080 = 8.5GB allocation).
+        ' Inline-draw only the visible pixel grid lines directly into
+        ' SCRN.CANVAS; LINE clips at dst so cost is bounded by visible area.
+        DIM pgCacheFits AS INTEGER
+        pgCacheFits% = (zw& + 1 <= SCRN.w& AND zh& + 1 <= SCRN.h&)
+
+        IF pgCacheFits% THEN
+            ' Reuse cached pixel grid image if zoom/size/color/opacity unchanged
+            IF PG_CACHE_IMG& = 0 OR _
+               PG_CACHE_ZW& <> zw& OR _
+               PG_CACHE_ZH& <> zh& OR _
+               PG_CACHE_ZOOM% <> pzoom% OR _
+               PG_CACHE_COLOR~& <> pgColor~& OR _
+               PG_CACHE_OPACITY% <> pgOpacity% THEN
+                ' Cache miss — rebuild pixel grid image
+                IF PG_CACHE_IMG& < -1 THEN _FREEIMAGE PG_CACHE_IMG&
+                PG_CACHE_IMG&     = _NEWIMAGE(zw& + 1, zh& + 1, 32)
+                PG_CACHE_ZW&      = zw&
+                PG_CACHE_ZH&      = zh&
+                PG_CACHE_ZOOM%    = pzoom%
+                PG_CACHE_COLOR~&  = pgColor~&
+                PG_CACHE_OPACITY% = pgOpacity%
+                _DEST PG_CACHE_IMG&
+                CLS , _RGBA32(0, 0, 0, 0)
+                ' Draw vertical lines between each pixel column
+                FOR pgx% = 0 TO SCRN.canvasW&
+                    LINE (pgx% * pzoom%, 0)-(pgx% * pzoom%, zh&), pgColor~&
+                NEXT pgx%
+                ' Draw horizontal lines between each pixel row
+                FOR pgy% = 0 TO SCRN.canvasH&
+                    LINE (0, pgy% * pzoom%)-(zw&, pgy% * pzoom%), pgColor~&
+                NEXT pgy%
+                ' Apply resolved opacity globally to all drawn pixels
+                _SETALPHA pgOpacity%, pgColor~& TO pgColor~&, PG_CACHE_IMG&
+            END IF
+            ' Composite cached pixel grid onto canvas
+            _DEST SCRN.CANVAS&
+            _BLEND SCRN.CANVAS&
+            _PUTIMAGE (dx%, dy%), PG_CACHE_IMG&
+        ELSE
+            ' Free stale cache from a previous fits-viewport zoom level
             IF PG_CACHE_IMG& < -1 THEN _FREEIMAGE PG_CACHE_IMG&
-            PG_CACHE_IMG&     = _NEWIMAGE(zw& + 1, zh& + 1, 32)
-            PG_CACHE_ZW&      = zw&
-            PG_CACHE_ZH&      = zh&
-            PG_CACHE_ZOOM%    = pzoom%
-            PG_CACHE_COLOR~&  = pgColor~&
-            PG_CACHE_OPACITY% = pgOpacity%
-            _DEST PG_CACHE_IMG&
-            CLS , _RGBA32(0, 0, 0, 0)
-            ' Draw vertical lines between each pixel column
-            FOR pgx% = 0 TO SCRN.canvasW&
-                LINE (pgx% * pzoom%, 0)-(pgx% * pzoom%, zh&), pgColor~&
+            PG_CACHE_IMG&    = 0
+            PG_CACHE_ZW&     = 0
+            PG_CACHE_ZH&     = 0
+            PG_CACHE_ZOOM%   = 0
+
+            ' Pre-mix alpha into the line color (no _SETALPHA pass needed)
+            DIM pgInlineColor AS _UNSIGNED LONG
+            pgInlineColor~& = _RGBA32(_RED32(pgColor~&), _GREEN32(pgColor~&), _BLUE32(pgColor~&), pgOpacity%)
+
+            ' Compute visible canvas-pixel range so we don't loop the full grid
+            DIM pgVisX1 AS LONG, pgVisX2 AS LONG, pgVisY1 AS LONG, pgVisY2 AS LONG
+            pgVisX1& = 0
+            pgVisX2& = SCRN.canvasW&
+            pgVisY1& = 0
+            pgVisY2& = SCRN.canvasH&
+            ' Clamp to what's actually visible on SCRN.CANVAS (dx + cx*pzoom in [0, SCRN.w-1])
+            IF dx% < 0 THEN
+                pgVisX1& = (-dx%) \ pzoom%
+                IF pgVisX1& < 0 THEN pgVisX1& = 0
+            END IF
+            IF dx% + zw& > SCRN.w& THEN
+                pgVisX2& = (SCRN.w& - 1 - dx%) \ pzoom% + 1
+                IF pgVisX2& > SCRN.canvasW& THEN pgVisX2& = SCRN.canvasW&
+            END IF
+            IF dy% < 0 THEN
+                pgVisY1& = (-dy%) \ pzoom%
+                IF pgVisY1& < 0 THEN pgVisY1& = 0
+            END IF
+            IF dy% + zh& > SCRN.h& THEN
+                pgVisY2& = (SCRN.h& - 1 - dy%) \ pzoom% + 1
+                IF pgVisY2& > SCRN.canvasH& THEN pgVisY2& = SCRN.canvasH&
+            END IF
+
+            _DEST SCRN.CANVAS&
+            _BLEND SCRN.CANVAS&
+            ' Vertical lines: only visible canvas-x range
+            DIM pgVlineY1 AS LONG, pgVlineY2 AS LONG
+            pgVlineY1& = dy%
+            pgVlineY2& = dy% + zh&
+            IF pgVlineY1& < 0 THEN pgVlineY1& = 0
+            IF pgVlineY2& > SCRN.h& - 1 THEN pgVlineY2& = SCRN.h& - 1
+            FOR pgx% = pgVisX1& TO pgVisX2&
+                LINE (dx% + pgx% * pzoom%, pgVlineY1&)-(dx% + pgx% * pzoom%, pgVlineY2&), pgInlineColor~&
             NEXT pgx%
-            ' Draw horizontal lines between each pixel row
-            FOR pgy% = 0 TO SCRN.canvasH&
-                LINE (0, pgy% * pzoom%)-(zw&, pgy% * pzoom%), pgColor~&
+            ' Horizontal lines: only visible canvas-y range
+            DIM pgHlineX1 AS LONG, pgHlineX2 AS LONG
+            pgHlineX1& = dx%
+            pgHlineX2& = dx% + zw&
+            IF pgHlineX1& < 0 THEN pgHlineX1& = 0
+            IF pgHlineX2& > SCRN.w& - 1 THEN pgHlineX2& = SCRN.w& - 1
+            FOR pgy% = pgVisY1& TO pgVisY2&
+                LINE (pgHlineX1&, dy% + pgy% * pzoom%)-(pgHlineX2&, dy% + pgy% * pzoom%), pgInlineColor~&
             NEXT pgy%
-            ' Apply resolved opacity globally to all drawn pixels
-            _SETALPHA pgOpacity%, pgColor~& TO pgColor~&, PG_CACHE_IMG&
         END IF
-        ' Composite cached pixel grid onto canvas
-        _DEST SCRN.CANVAS&
-        _BLEND SCRN.CANVAS&
-        _PUTIMAGE (dx%, dy%), PG_CACHE_IMG&
     END IF
 END SUB
 

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -447,18 +447,22 @@ SUB SCREEN_snap_window_to_scale (newW AS LONG, newH AS LONG)
     ' Save old handles for cleanup
     oldCanvas& = SCRN.CANVAS&
     oldGUI&    = SCRN.GUI&
+    DIM oldCanvasHW AS LONG : oldCanvasHW& = SCRN.CANVAS_HW&
 
     ' Update viewport dimensions
     SCRN.w& = newVpW&
     SCRN.h& = newVpH&
 
-    ' Recreate viewport-sized image buffers
-    SCRN.CANVAS& = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.GUI&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Recreate viewport-sized image buffers.  CANVAS_HW is lazy-allocated
+    ' by the final-blit path; just drop the stale one so it gets rebuilt.
+    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.CANVAS_HW& = 0
+    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
 
     ' Free old buffers (after creating new ones so _DEST never points to freed handle)
     IF oldCanvas& < -1 THEN _FREEIMAGE oldCanvas&
     IF oldGUI& < -1 THEN _FREEIMAGE oldGUI&
+    IF oldCanvasHW& < -1 THEN _FREEIMAGE oldCanvasHW&
 
     ' Recreate OS window at correctly scaled size (snap to integer multiple)
     winW& = SCRN.w& * SCRN.displayScale%
@@ -703,10 +707,14 @@ SUB SCREEN_init ()
     SCRN.showCanvasBorder%              = TRUE
     SCRN.canvasBorderOpacity%           = 100
 
-    ' Create image buffers (canvas at viewport size, painting at canvas size)
-    SCRN.CANVAS&   = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.PAINTING& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
-    SCRN.GUI&      = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Create image buffers (canvas at viewport size, painting at canvas size).
+    ' CANVAS_HW& (hardware image, mode 33) is allocated lazily on first final-blit
+    ' call — mode 33 requires an active GL context which only exists after
+    ' SCREEN _NEWIMAGE switches into graphics mode (a few lines below).
+    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.CANVAS_HW& = 0
+    SCRN.PAINTING&  = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
+    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
     ' SCRN.CURSOR& removed — cursors now draw directly onto SCRN.CANVAS&
     
     _DEST SCRN.PAINTING&
@@ -3551,7 +3559,34 @@ SUB SCREEN_render ()
             _MEMFREE grsFrame
         END IF
     END IF
-    _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
+    ' Upload software canvas to a fresh hardware image, then GPU-stretch via
+    ' two triangles covering screen 0.  Replaces the CPU-bound software
+    ' upscale that was 63-80% of render time.
+    '
+    ' Hardware images in QB64-PE are immutable: to update we _FREEIMAGE the
+    ' old one and _COPYIMAGE the software canvas with mode 33.  The copy is
+    ' the GPU texture upload — bounded by SCRN.w * SCRN.h pixels (not by
+    ' the larger destination), which is the whole point.
+    IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
+    SCRN.CANVAS_HW& = _COPYIMAGE(SCRN.CANVAS&, 33)
+    IF SCRN.CANVAS_HW& < -1 THEN
+        DIM finOldDest AS LONG : finOldDest& = _DEST
+        _DEST 0
+        DIM finScaleSW AS LONG, finScaleSH AS LONG
+        DIM finScaleDW AS LONG, finScaleDH AS LONG
+        finScaleSW& = SCRN.w&     - 1
+        finScaleSH& = SCRN.h&     - 1
+        finScaleDW& = _WIDTH(0)   - 1
+        finScaleDH& = _HEIGHT(0)  - 1
+        ' Triangle 1: top-left half (covers along the (0,0)-(W,H) diagonal)
+        _MAPTRIANGLE (0, 0)-(0, finScaleSH&)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(0, finScaleDH&)-(finScaleDW&, finScaleDH&)
+        ' Triangle 2: top-right half
+        _MAPTRIANGLE (0, 0)-(finScaleSW&, 0)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(finScaleDW&, 0)-(finScaleDW&, finScaleDH&)
+        _DEST finOldDest&
+    ELSE
+        ' Fallback (HW image unavailable) — original CPU upscale path
+        _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
+    END IF
     PERF_stop PERF_FINAL_SCALE
 
     ' ==== FLOATING PANELS (after canvas upscale, draw directly to screen 0) ====

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -447,22 +447,18 @@ SUB SCREEN_snap_window_to_scale (newW AS LONG, newH AS LONG)
     ' Save old handles for cleanup
     oldCanvas& = SCRN.CANVAS&
     oldGUI&    = SCRN.GUI&
-    DIM oldCanvasHW AS LONG : oldCanvasHW& = SCRN.CANVAS_HW&
 
     ' Update viewport dimensions
     SCRN.w& = newVpW&
     SCRN.h& = newVpH&
 
-    ' Recreate viewport-sized image buffers.  CANVAS_HW is lazy-allocated
-    ' by the final-blit path; just drop the stale one so it gets rebuilt.
-    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.CANVAS_HW& = 0
-    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Recreate viewport-sized image buffers
+    SCRN.CANVAS& = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.GUI&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
 
     ' Free old buffers (after creating new ones so _DEST never points to freed handle)
     IF oldCanvas& < -1 THEN _FREEIMAGE oldCanvas&
     IF oldGUI& < -1 THEN _FREEIMAGE oldGUI&
-    IF oldCanvasHW& < -1 THEN _FREEIMAGE oldCanvasHW&
 
     ' Recreate OS window at correctly scaled size (snap to integer multiple)
     winW& = SCRN.w& * SCRN.displayScale%
@@ -707,14 +703,10 @@ SUB SCREEN_init ()
     SCRN.showCanvasBorder%              = TRUE
     SCRN.canvasBorderOpacity%           = 100
 
-    ' Create image buffers (canvas at viewport size, painting at canvas size).
-    ' CANVAS_HW& (hardware image, mode 33) is allocated lazily on first final-blit
-    ' call — mode 33 requires an active GL context which only exists after
-    ' SCREEN _NEWIMAGE switches into graphics mode (a few lines below).
-    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.CANVAS_HW& = 0
-    SCRN.PAINTING&  = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
-    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Create image buffers (canvas at viewport size, painting at canvas size)
+    SCRN.CANVAS&   = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.PAINTING& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
+    SCRN.GUI&      = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
     ' SCRN.CURSOR& removed — cursors now draw directly onto SCRN.CANVAS&
     
     _DEST SCRN.PAINTING&
@@ -3598,34 +3590,7 @@ SUB SCREEN_render ()
             _MEMFREE grsFrame
         END IF
     END IF
-    ' Upload software canvas to a fresh hardware image, then GPU-stretch via
-    ' two triangles covering screen 0.  Replaces the CPU-bound software
-    ' upscale that was 63-80% of render time.
-    '
-    ' Hardware images in QB64-PE are immutable: to update we _FREEIMAGE the
-    ' old one and _COPYIMAGE the software canvas with mode 33.  The copy is
-    ' the GPU texture upload — bounded by SCRN.w * SCRN.h pixels (not by
-    ' the larger destination), which is the whole point.
-    IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
-    SCRN.CANVAS_HW& = _COPYIMAGE(SCRN.CANVAS&, 33)
-    IF SCRN.CANVAS_HW& < -1 THEN
-        DIM finOldDest AS LONG : finOldDest& = _DEST
-        _DEST 0
-        DIM finScaleSW AS LONG, finScaleSH AS LONG
-        DIM finScaleDW AS LONG, finScaleDH AS LONG
-        finScaleSW& = SCRN.w&     - 1
-        finScaleSH& = SCRN.h&     - 1
-        finScaleDW& = _WIDTH(0)   - 1
-        finScaleDH& = _HEIGHT(0)  - 1
-        ' Triangle 1: top-left half (covers along the (0,0)-(W,H) diagonal)
-        _MAPTRIANGLE (0, 0)-(0, finScaleSH&)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(0, finScaleDH&)-(finScaleDW&, finScaleDH&)
-        ' Triangle 2: top-right half
-        _MAPTRIANGLE (0, 0)-(finScaleSW&, 0)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(finScaleDW&, 0)-(finScaleDW&, finScaleDH&)
-        _DEST finOldDest&
-    ELSE
-        ' Fallback (HW image unavailable) — original CPU upscale path
-        _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
-    END IF
+    _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
     PERF_stop PERF_FINAL_SCALE
 
     ' ==== FLOATING PANELS (after canvas upscale, draw directly to screen 0) ====

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -2579,7 +2579,14 @@ SUB SCREEN_render ()
     ' GUI overlay onto the cached scene. Avoids expensive layer compositing,
     ' grid rendering, and transparency checkerboard.
     ' ========================================================================
-    IF NOT SCENE_DIRTY% AND GUI_NEEDS_REDRAW% AND SCENE_CACHE& <> 0 THEN
+    ' DISABLED while HW final-scale is active: the partial-restore-then-overlay
+    ' sequence leaves residual sub-255 alpha pixels on SCRN.CANVAS from
+    ' previous tooltip BG draws.  Those punch transparent holes into the HW1
+    ' framebuffer at HW present time, preserving stale prior-frame content =>
+    ' ghost-trail tooltips.  Full path's CLS , apron resets alpha = 255 every
+    ' frame, eliminating the leak.  Cost of always-full-path is +3-5ms per
+    ' dirty frame; the HW final scale saves ~18ms, so net we still win big.
+    IF FALSE AND NOT SCENE_DIRTY% AND GUI_NEEDS_REDRAW% AND SCENE_CACHE& <> 0 THEN
         PERF_start PERF_GUI_ONLY_PATH
         SCREEN_compute_layout
         ' Re-render GUI elements with updated content
@@ -2667,7 +2674,8 @@ SUB SCREEN_render ()
     ' Never touches the palette strip swatch loop or does any full-frame copy.
     ' Falls back to SkipToPointer only when partial present is unsafe.
     ' ========================================================================
-    IF NOT SCENE_DIRTY% AND NOT GUI_NEEDS_REDRAW% AND STATUS_NEEDS_REDRAW% AND SCENE_CACHE& <> 0 THEN
+    ' DISABLED while HW final-scale is active (see GUI-only path comment above)
+    IF FALSE AND NOT SCENE_DIRTY% AND NOT GUI_NEEDS_REDRAW% AND STATUS_NEEDS_REDRAW% AND SCENE_CACHE& <> 0 THEN
         PERF_start PERF_GUI_ONLY_PATH
         ' SCREEN_compute_layout is intentionally skipped here.
         ' STATUS-ONLY fires only when NOT GUI_NEEDS_REDRAW%, meaning the GUI
@@ -2884,7 +2892,8 @@ SUB SCREEN_render ()
     ' only the regions that need updating (pointer area + selection overlay)
     ' instead of copying and scaling the full canvas every frame.
     ' ========================================================================
-    IF NOT SCENE_DIRTY% AND SCENE_CACHE& <> 0 AND NOT SCRN.patternTileMode% THEN
+    ' DISABLED while HW final-scale is active (see GUI-only path comment above)
+    IF FALSE AND NOT SCENE_DIRTY% AND SCENE_CACHE& <> 0 AND NOT SCRN.patternTileMode% THEN
         ' Skip dirty-rect optimization when popup overlays are open — they need
         ' full-frame consistency to avoid flicker and z-order artifacts with scrollbars.
         IF LAYER_PANEL.blendPopupOpen% OR DRAWER.contextMenuOpen% OR CMD_PALETTE.visible THEN
@@ -3598,30 +3607,42 @@ SUB SCREEN_render ()
             _MEMFREE grsFrame
         END IF
     END IF
-    ' Upload software canvas to a fresh hardware image, then GPU-stretch via
-    ' two triangles covering screen 0.  Replaces the CPU-bound software
-    ' upscale that was 63-80% of render time.
+    ' Upload software canvas to a fresh hardware image, then blit to screen 0
+    ' with stretch.  Hardware-image source enables _PUTIMAGE's GL path
+    ' (GPU texture mapping), replacing the CPU-bound software upscale that
+    ' was 63-80% of render time.
     '
     ' Hardware images in QB64-PE are immutable: to update we _FREEIMAGE the
     ' old one and _COPYIMAGE the software canvas with mode 33.  The copy is
     ' the GPU texture upload — bounded by SCRN.w * SCRN.h pixels (not by
     ' the larger destination), which is the whole point.
+    '
+    ' Critical: force every SCRN.CANVAS pixel to alpha=255 before snapshotting.
+    ' QB64-PE's _BLEND-mode draws with _RGBA32(..., alpha<255) corrupt the
+    ' destination alpha (down to 0 in some cases), leaving transparent holes
+    ' that alpha-blend with the GL HW1 framebuffer at HW present time —
+    ' preserving prior frame content where alpha is 0 → tooltip ghost trails.
+    '
+    ' _SETALPHA can't fix this (verified — it doesn't lift alpha-0 pixels
+    ' back to opaque even with correct syntax).  Walk the canvas memory
+    ' directly: every 4th byte (the alpha byte at offset +3 in each 32-bit
+    ' pixel) gets forced to 255.  Cost: ~1-2ms for SCRN.w × SCRN.h pixels.
+    DIM fsCanvasMem AS _MEM
+    DIM fsAlphaOff  AS _OFFSET, fsAlphaEnd AS _OFFSET
+    fsCanvasMem = _MEMIMAGE(SCRN.CANVAS&)
+    IF fsCanvasMem.SIZE > 0 THEN
+        fsAlphaOff = fsCanvasMem.OFFSET + 3
+        fsAlphaEnd = fsCanvasMem.OFFSET + fsCanvasMem.SIZE
+        DO WHILE fsAlphaOff < fsAlphaEnd
+            _MEMPUT fsCanvasMem, fsAlphaOff, 255 AS _UNSIGNED _BYTE
+            fsAlphaOff = fsAlphaOff + 4
+        LOOP
+    END IF
+    _MEMFREE fsCanvasMem
     IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
     SCRN.CANVAS_HW& = _COPYIMAGE(SCRN.CANVAS&, 33)
     IF SCRN.CANVAS_HW& < -1 THEN
-        DIM finOldDest AS LONG : finOldDest& = _DEST
-        _DEST 0
-        DIM finScaleSW AS LONG, finScaleSH AS LONG
-        DIM finScaleDW AS LONG, finScaleDH AS LONG
-        finScaleSW& = SCRN.w&     - 1
-        finScaleSH& = SCRN.h&     - 1
-        finScaleDW& = _WIDTH(0)   - 1
-        finScaleDH& = _HEIGHT(0)  - 1
-        ' Triangle 1: top-left half (covers along the (0,0)-(W,H) diagonal)
-        _MAPTRIANGLE (0, 0)-(0, finScaleSH&)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(0, finScaleDH&)-(finScaleDW&, finScaleDH&)
-        ' Triangle 2: top-right half
-        _MAPTRIANGLE (0, 0)-(finScaleSW&, 0)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(finScaleDW&, 0)-(finScaleDW&, finScaleDH&)
-        _DEST finOldDest&
+        _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS_HW&, 0
     ELSE
         ' Fallback (HW image unavailable) — original CPU upscale path
         _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -447,18 +447,22 @@ SUB SCREEN_snap_window_to_scale (newW AS LONG, newH AS LONG)
     ' Save old handles for cleanup
     oldCanvas& = SCRN.CANVAS&
     oldGUI&    = SCRN.GUI&
+    DIM oldCanvasHW AS LONG : oldCanvasHW& = SCRN.CANVAS_HW&
 
     ' Update viewport dimensions
     SCRN.w& = newVpW&
     SCRN.h& = newVpH&
 
-    ' Recreate viewport-sized image buffers
-    SCRN.CANVAS& = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.GUI&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Recreate viewport-sized image buffers.  CANVAS_HW is lazy-allocated
+    ' by the final-blit path; just drop the stale one so it gets rebuilt.
+    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.CANVAS_HW& = 0
+    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
 
     ' Free old buffers (after creating new ones so _DEST never points to freed handle)
     IF oldCanvas& < -1 THEN _FREEIMAGE oldCanvas&
     IF oldGUI& < -1 THEN _FREEIMAGE oldGUI&
+    IF oldCanvasHW& < -1 THEN _FREEIMAGE oldCanvasHW&
 
     ' Recreate OS window at correctly scaled size (snap to integer multiple)
     winW& = SCRN.w& * SCRN.displayScale%
@@ -703,10 +707,14 @@ SUB SCREEN_init ()
     SCRN.showCanvasBorder%              = TRUE
     SCRN.canvasBorderOpacity%           = 100
 
-    ' Create image buffers (canvas at viewport size, painting at canvas size)
-    SCRN.CANVAS&   = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
-    SCRN.PAINTING& = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
-    SCRN.GUI&      = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    ' Create image buffers (canvas at viewport size, painting at canvas size).
+    ' CANVAS_HW& (hardware image, mode 33) is allocated lazily on first final-blit
+    ' call — mode 33 requires an active GL context which only exists after
+    ' SCREEN _NEWIMAGE switches into graphics mode (a few lines below).
+    SCRN.CANVAS&    = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
+    SCRN.CANVAS_HW& = 0
+    SCRN.PAINTING&  = _NEWIMAGE(SCRN.canvasW&, SCRN.canvasH&, 32)
+    SCRN.GUI&       = _NEWIMAGE(SCRN.w&, SCRN.h&, 32)
     ' SCRN.CURSOR& removed — cursors now draw directly onto SCRN.CANVAS&
     
     _DEST SCRN.PAINTING&
@@ -3590,7 +3598,34 @@ SUB SCREEN_render ()
             _MEMFREE grsFrame
         END IF
     END IF
-    _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
+    ' Upload software canvas to a fresh hardware image, then GPU-stretch via
+    ' two triangles covering screen 0.  Replaces the CPU-bound software
+    ' upscale that was 63-80% of render time.
+    '
+    ' Hardware images in QB64-PE are immutable: to update we _FREEIMAGE the
+    ' old one and _COPYIMAGE the software canvas with mode 33.  The copy is
+    ' the GPU texture upload — bounded by SCRN.w * SCRN.h pixels (not by
+    ' the larger destination), which is the whole point.
+    IF SCRN.CANVAS_HW& < -1 THEN _FREEIMAGE SCRN.CANVAS_HW&
+    SCRN.CANVAS_HW& = _COPYIMAGE(SCRN.CANVAS&, 33)
+    IF SCRN.CANVAS_HW& < -1 THEN
+        DIM finOldDest AS LONG : finOldDest& = _DEST
+        _DEST 0
+        DIM finScaleSW AS LONG, finScaleSH AS LONG
+        DIM finScaleDW AS LONG, finScaleDH AS LONG
+        finScaleSW& = SCRN.w&     - 1
+        finScaleSH& = SCRN.h&     - 1
+        finScaleDW& = _WIDTH(0)   - 1
+        finScaleDH& = _HEIGHT(0)  - 1
+        ' Triangle 1: top-left half (covers along the (0,0)-(W,H) diagonal)
+        _MAPTRIANGLE (0, 0)-(0, finScaleSH&)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(0, finScaleDH&)-(finScaleDW&, finScaleDH&)
+        ' Triangle 2: top-right half
+        _MAPTRIANGLE (0, 0)-(finScaleSW&, 0)-(finScaleSW&, finScaleSH&), SCRN.CANVAS_HW& TO (0, 0)-(finScaleDW&, 0)-(finScaleDW&, finScaleDH&)
+        _DEST finOldDest&
+    ELSE
+        ' Fallback (HW image unavailable) — original CPU upscale path
+        _PUTIMAGE (0, 0)-(_WIDTH(0) - 1, _HEIGHT(0) - 1), SCRN.CANVAS&, 0
+    END IF
     PERF_stop PERF_FINAL_SCALE
 
     ' ==== FLOATING PANELS (after canvas upscale, draw directly to screen 0) ====

--- a/TOOLS/SYMMETRY.BM
+++ b/TOOLS/SYMMETRY.BM
@@ -184,84 +184,90 @@ END SUB
 ' @param zh LONG Zoomed canvas height in display pixels
 ' @param zoom SINGLE Current zoom level for scaling guide elements
 ' 
-SUB SYMMETRY_render_guides (zw&, zh&, zoom!)
+' Render symmetry guides directly into dstImg at offset (dxOffset, dyOffset).
+' Previously this used an intermediate SYMMETRY.imgHandle& sized to (zw, zh) +
+' a _PUTIMAGE blit — at zoom 32x on 1920x1080 that's an 8.5 GB allocation and
+' a per-frame CLS of 2 billion pixels.  Drawing directly is just ~6 LINE calls
+' clipped at the destination bounds.
+SUB SYMMETRY_render_guides (dstImg AS LONG, dxOffset AS INTEGER, dyOffset AS INTEGER, zw AS LONG, zh AS LONG, zoom AS SINGLE)
     DIM oldDest AS LONG
     DIM AS INTEGER x1, y1, x2, y2
     DIM AS INTEGER centerX, centerY
-    
-    ' Calculate center in zoomed display coordinates
-    centerX% = SYMMETRY.CENTER_X% * zoom!
-    centerY% = SYMMETRY.CENTER_Y% * zoom!
-    
-    ' (Logging removed from render path for performance)
+
+    IF SYMMETRY.MODE% <= 0 THEN EXIT SUB
+
+    ' Calculate center in viewport (screen) coordinates
+    centerX% = dxOffset% + SYMMETRY.CENTER_X% * zoom!
+    centerY% = dyOffset% + SYMMETRY.CENTER_Y% * zoom!
+
     oldDest& = _DEST
-    _DEST SYMMETRY.imgHandle&
-    CLS , _RGBA32(0, 0, 0, 0) ' Clear with transparency
-    
-    IF SYMMETRY.MODE% > 0 THEN
-            ' Use theme colors directly (already _RGBA32 values)
-            DIM guideRGBA AS _UNSIGNED LONG
-            guideRGBA~& = THEME.SYMMETRY_guide_fg~&
-            
-            ' Draw guide lines based on mode
-            SELECT CASE SYMMETRY.MODE%
-                CASE 1 ' VERTICAL (|)
-                    ' Vertical line through center
-                    LINE (centerX%, 0)-(centerX%, zh& - 1), guideRGBA~&
-                    
-                CASE 2 ' CROSS (+)
-                    ' Vertical line
-                    LINE (centerX%, 0)-(centerX%, zh& - 1), guideRGBA~&
-                    ' Horizontal line
-                    LINE (0, centerY%)-(zw& - 1, centerY%), guideRGBA~&
-                    
-                CASE 3 ' ASTERISK (*)
-                    ' Vertical line
-                    LINE (centerX%, 0)-(centerX%, zh& - 1), guideRGBA~&
-                    ' Horizontal line
-                    LINE (0, centerY%)-(zw& - 1, centerY%), guideRGBA~&
-                    ' Diagonal lines (45°)
-                    ' Top-left to bottom-right
-                    x1% = centerX% - centerY%
-                    y1% = 0
-                    x2% = centerX% + (zh& - 1 - centerY%)
-                    y2% = zh& - 1
-                    IF x1% < 0 THEN
-                        y1% = -x1%
-                        x1% = 0
-                    END IF
-                    IF x2% >= zw& THEN
-                        y2% = y2% - (x2% - zw& + 1)
-                        x2% = zw& - 1
-                    END IF
-                    LINE (x1%, y1%)-(x2%, y2%), guideRGBA~&
-                    
-                    ' Top-right to bottom-left
-                    x1% = centerX% + centerY%
-                    y1% = 0
-                    x2% = centerX% - (zh& - 1 - centerY%)
-                    y2% = zh& - 1
-                    IF x1% >= zw& THEN
-                        y1% = x1% - zw& + 1
-                        x1% = zw& - 1
-                    END IF
-                    IF x2% < 0 THEN
-                        y2% = y2% + x2%
-                        x2% = 0
-                    END IF
-                    LINE (x1%, y1%)-(x2%, y2%), guideRGBA~&
-            END SELECT
-            
-            ' Draw center crosshair dot (5x5 pixels scaled with zoom)
-            DIM centerRGBA    AS _UNSIGNED LONG
-            DIM crosshairSize AS INTEGER
-            centerRGBA~&   = THEME.SYMMETRY_center_fg~&
-            crosshairSize% = 2 * zoom!
-            IF crosshairSize% < 2 THEN crosshairSize% = 2
-            LINE (centerX% - crosshairSize%, centerY% - crosshairSize%)-(centerX% + crosshairSize%, centerY% + crosshairSize%), _
-                centerRGBA~&, BF
-        END IF
-        
-        _DEST oldDest&
-        ' (Logging removed from render path for performance)
+    _DEST dstImg&
+    _BLEND dstImg&
+
+    ' Use theme colors directly (already _RGBA32 values)
+    DIM guideRGBA AS _UNSIGNED LONG
+    guideRGBA~& = THEME.SYMMETRY_guide_fg~&
+
+    ' Guide extents in viewport coordinates (LINE clips at dst bounds)
+    DIM gLeft   AS INTEGER, gRight  AS INTEGER
+    DIM gTop    AS INTEGER, gBottom AS INTEGER
+    gLeft%   = dxOffset%
+    gRight%  = dxOffset% + zw& - 1
+    gTop%    = dyOffset%
+    gBottom% = dyOffset% + zh& - 1
+
+    ' Draw guide lines based on mode
+    SELECT CASE SYMMETRY.MODE%
+        CASE 1 ' VERTICAL (|)
+            LINE (centerX%, gTop%)-(centerX%, gBottom%), guideRGBA~&
+
+        CASE 2 ' CROSS (+)
+            LINE (centerX%, gTop%)-(centerX%, gBottom%), guideRGBA~&
+            LINE (gLeft%, centerY%)-(gRight%, centerY%), guideRGBA~&
+
+        CASE 3 ' ASTERISK (*)
+            LINE (centerX%, gTop%)-(centerX%, gBottom%), guideRGBA~&
+            LINE (gLeft%, centerY%)-(gRight%, centerY%), guideRGBA~&
+            ' Diagonals (45°), endpoints clamped to canvas-in-viewport rect.
+            ' Top-left to bottom-right
+            x1% = centerX% - (centerY% - gTop%)
+            y1% = gTop%
+            x2% = centerX% + (gBottom% - centerY%)
+            y2% = gBottom%
+            IF x1% < gLeft% THEN
+                y1% = y1% + (gLeft% - x1%)
+                x1% = gLeft%
+            END IF
+            IF x2% > gRight% THEN
+                y2% = y2% - (x2% - gRight%)
+                x2% = gRight%
+            END IF
+            LINE (x1%, y1%)-(x2%, y2%), guideRGBA~&
+
+            ' Top-right to bottom-left
+            x1% = centerX% + (centerY% - gTop%)
+            y1% = gTop%
+            x2% = centerX% - (gBottom% - centerY%)
+            y2% = gBottom%
+            IF x1% > gRight% THEN
+                y1% = y1% + (x1% - gRight%)
+                x1% = gRight%
+            END IF
+            IF x2% < gLeft% THEN
+                y2% = y2% - (gLeft% - x2%)
+                x2% = gLeft%
+            END IF
+            LINE (x1%, y1%)-(x2%, y2%), guideRGBA~&
+    END SELECT
+
+    ' Center crosshair dot (scaled with zoom; min 2px)
+    DIM centerRGBA    AS _UNSIGNED LONG
+    DIM crosshairSize AS INTEGER
+    centerRGBA~&   = THEME.SYMMETRY_center_fg~&
+    crosshairSize% = 2 * zoom!
+    IF crosshairSize% < 2 THEN crosshairSize% = 2
+    LINE (centerX% - crosshairSize%, centerY% - crosshairSize%)-(centerX% + crosshairSize%, centerY% + crosshairSize%), _
+        centerRGBA~&, BF
+
+    _DEST oldDest&
 END SUB


### PR DESCRIPTION
# Render pipeline performance pass — 4-5× speedup at 1920×1080

## Summary

Cut DRAW's full-frame render time from **23–29ms → 5–8ms** on a 1920×1080 canvas (4–5× faster). Frame budget usage at 60 fps drops from **138–177%** (well over) to **30–47%** (comfortable headroom). User-reported "ages to zoom out" symptom is gone.

The work also documents and works around two non-obvious QB64-PE quirks: alpha-blend draws with `_RGBA32(..., alpha<255)` corrupt destination alpha, and `_PUTIMAGE` with hardware-image source (mode 33) honors that source alpha when blitting to `SCREEN 0`, alpha-blending with HW1's prior-frame content.

## Architecture changes

| Area | Change |
|---|---|
| `OUTPUT/SCREEN.BM` — final present | Software canvas → `_COPYIMAGE(SCRN.CANVAS&, 33)` hardware image → `_PUTIMAGE` to screen 0. GPU-stretched. **18ms → ~1ms.** Largest single win. |
| `OUTPUT/SCREEN.BM` — render dispatch | GUI-only / STATUS-only / dirty-rect partial paths gated off (`FALSE AND ...`). Every dirty frame now runs the full path with `CLS , apron color` to reset SCRN.CANVAS alpha state. Required to prevent HW1 ghost trails — see "Quirks documented" below. |
| `OUTPUT/SCREEN.BM` — alpha defense | `_MEM`-based pass over SCRN.CANVAS forces every alpha byte to 255 right before `_COPYIMAGE`. Belt-and-suspenders with the always-full-path. Costs ~1ms. |
| `DRAW.BAS` — cursor FPS cap | Cursor-only `_LIMIT` switched from `CFG.FPS_CURSOR%` (240) to `CFG.FPS_LIMIT%` (60). Necessary now that cursor movement triggers full-path renders instead of the old cheap STATUS-only partials. |

## Cache architecture (multiple files)

Recurring pattern: build at high-cost resolution once, cap cache size to viewport bounds, fall back to inline draw for extreme zoom.

- `GUI/TRANSPARENCY.BM` — two-level cache (canvas-res blueprint + display-rect blit cache). Per-frame draw is a no-scale memcpy. Viewport-bounded; falls back to direct blueprint blit at extreme zoom.
- `GUI/GRID.BM` (square-grid zoom-<1.0 path in `RENDER_grids`) — screen-space cache survives panning and zoom. Viewport-bounded; falls back to inline `LINE` loop when canvas display exceeds viewport.
- `GUI/GRID.BM` — pixel grid (`PG_CACHE_IMG&`) — viewport-bounded; falls back to inline `LINE` loop covering only visible canvas-pixel range at extreme zoom (was previously trying to allocate a `_NEWIMAGE(zw+1, zh+1, 32)` which at zoom 32× on 1920×1080 = **8.5 GB**).
- `GUI/GRID.BM` — removed `PIXEL_GRID.imgHandle&` phantom cache (allocated + filled every init/load/resize but never read).
- `TOOLS/SYMMETRY.BM` — removed `SYMMETRY.imgHandle&` intermediate image (same phantom-cache antipattern — allocated 8.5 GB at zoom 32×, never had skip-on-clean logic, just CLS'd + redrew every frame). Symmetry guides now draw directly to the destination image.
- `OUTPUT/SCREEN.BM` — `RENDER_layers` trivial single-layer fast path: when there's exactly one visible non-group layer with opacity 255, NORMAL blend, no apron, no move-preview, skip the composite buffer entirely. PREVIEW reads from a new `CANVAS_CONTENT_SRC&` indirection that points at either `COMPOSITE_BUFFER&` (composite path) or directly at the layer's `imgHandle&` (trivial path).
- `OUTPUT/SCREEN.BM` — `COMPOSITE_RESULT_CACHE` save gated on `BLEND_needs_composite%`. The cache feeds the region-composite path which only runs when actual blend modes need it; when only PREVIEW forces the composite buffer to exist, skipping the cache save saves an 8MB memcpy/frame.

## New CLI flag + log file

- `--perf` flag enables per-section render-pipeline profiling. Logs averages every 120 frames to `DRAW-perf.log` (lazy-opened next to the executable). Implementation in `CORE/PERF.BI` + `CORE/PERF.BM`. Added to `--help` banner. Defensive skip branches added to `DRAW.BAS` file-arg loops.
- Already-existing `CORE/HELP.BI` (added earlier in this branch) lists every CLI option DRAW understands.

## QB64-PE quirks documented in code

Both with detailed comments at the call site so future maintainers don't lose another hour to these:

1. **`_PUTIMAGE` from hardware-image source to SCREEN 0 alpha-blends with the HW1 framebuffer.** Sub-255 source alpha preserves HW1's prior frame content. Causes ghost-trail accumulation. (`OUTPUT/SCREEN.BM` final-scale block.)
2. **`_BLEND`-mode draws with `_RGBA32(..., alpha<255)` zero the destination alpha** (not just alpha — color also affected). `_SETALPHA 255, img` cannot lift alpha-0 pixels back to opaque. The only reliable reset is `CLS , opaque-color` on the image. (Hence: always-full-path.)

## Performance comparison (1920×1080 canvas, 864×486 viewport)

| Section | Original | Final |
|---|---|---|
| `final scale` | **18ms** (63–80% of render) | **1.1ms** (14%) |
| `full: layers` | 3.5ms (~44%) | 0.83ms (10%) |
| `full: CLS+GUI` | 2.9ms (~35%) | 3.2ms (41%) |
| `full: checkerboard` | ~1ms | 0.1ms |
| `full: grids` | up to 1.1ms | <0.01ms |
| **RENDER TOTAL** | **23–29ms** | **7–8ms** |
| Budget @ 60fps | 138–177% | 30–47% |

## Trade-offs

- **Lost: partial render paths.** GUI-only, STATUS-only, and dirty-rect paths are gated off. The old "skip layer composite when only chrome changed" optimization is dropped. With our other optimizations (trivial single-layer, cached grids/checkerboard), the full path is now cheap enough that this is net positive. Conditions are preserved in code (commented why); easy to re-enable if a future fix addresses the HW1 alpha-leak directly.
- **Lost: 240 FPS cursor tracking.** Cursor-only movement now caps at FPS_LIMIT (60). Practically imperceptible for drawing work. `CFG.FPS_CURSOR%` field is preserved.
- **Risk: floating panels (`COLORMIXER_render`, `BROWSER_render`) that draw directly to screen 0 *after* the HW present are likely invisible** — HW renders on top of CPU writes in QB64-PE's compositing order. This was observed in isolation tests but the user hasn't reported it as a workflow issue, so deferred. Workaround if needed: composite those panels into SCRN.CANVAS before the HW snapshot.

## Test plan

- [x] `make` builds clean
- [x] `./DRAW.run --canvas-size 1920x1080 --perf` — no ghost trails on layer panel hover
- [x] `./DRAW.run` (no perf) — normal startup, file open, save, draw flows
- [x] `--help` / `-h` / `/?` / `-v` / `--version` show correct text
- [x] Zoom-in and zoom-out at 1920×1080 are responsive (`Z+0` to 3200%, `Z+1` to 100% — no progressive slowdown)
- [x] `draw-watch.sh` shows CPU under 80% in steady state (startup spike to ~100% for ~4s is normal initialization)
- [x] `DRAW-perf.log` confirms `final scale` ~1ms, `RENDER TOTAL` ~7-8ms

## Tags worth knowing

- `hw-image-reverted-but-3x-optimized` — known-good fallback state if HW final-scale ever has to be reverted again
- (suggest tagging this PR's head as `hw-image-recovered-stable` on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)