### PR TITLE
feat(palette): render color chips in the palette dropdown menu

### DIFF
--- a/CFG/CONFIG.BI
+++ b/CFG/CONFIG.BI
@@ -341,6 +341,7 @@ TYPE DRAW_CONFIG
     ' User palette visibility settings
     PALETTE_SHOW_LOSPEC             AS INTEGER        ' TRUE = include USER/PALETTES/*.gpl in picker
     PALETTE_SHOW_CREATED            AS INTEGER        ' TRUE = include USER/PALETTES/CREATED/*.gpl in picker
+    PALETTE_MENU_SHOW_CHIPS         AS INTEGER        ' TRUE = draw color chips beside names in the palette dropdown
     ' Color extraction max for "Create from image"
     PALETTE_CREATE_MAX_COLORS       AS INTEGER        ' Default max colors for Create from Image (default 32)
     ' Preview Window settings

--- a/CFG/CONFIG.BM
+++ b/CFG/CONFIG.BM
@@ -166,6 +166,7 @@ SUB CONFIG_set_defaults ()
     ' User palette visibility settings
     CFG.PALETTE_SHOW_LOSPEC%       = TRUE                                                 ' Show Lospec palettes in picker by default
     CFG.PALETTE_SHOW_CREATED%      = TRUE                                                 ' Show Created palettes in picker by default
+    CFG.PALETTE_MENU_SHOW_CHIPS%   = TRUE                                                 ' Show color chips beside names in palette dropdown
     CFG.PALETTE_CREATE_MAX_COLORS% = 32                                                   ' Default max colors for Create from Image
     ' Preview Window settings
     CFG.PREVIEW_VISIBLE%              = TRUE                                              ' Preview window visible by default
@@ -770,6 +771,8 @@ SUB CONFIG_load ()
                         CFG.PALETTE_SHOW_LOSPEC% = VAL(configValue$)
                     CASE "PALETTE_SHOW_CREATED"
                         CFG.PALETTE_SHOW_CREATED% = VAL(configValue$)
+                    CASE "PALETTE_MENU_SHOW_CHIPS"
+                        CFG.PALETTE_MENU_SHOW_CHIPS% = VAL(configValue$)
                     CASE "PALETTE_CREATE_MAX_COLORS"
                         CFG.PALETTE_CREATE_MAX_COLORS% = VAL(configValue$)
                     CASE "PREVIEW_VISIBLE"
@@ -1560,6 +1563,7 @@ SUB CONFIG_save ()
     PRINT #fh%, "PALETTE_PICKER_COLUMNS=" + _TRIM$(STR$(CFG.PALETTE_PICKER_COLUMNS%))
     PRINT #fh%, "PALETTE_SHOW_LOSPEC=" + _TRIM$(STR$(CFG.PALETTE_SHOW_LOSPEC%))
     PRINT #fh%, "PALETTE_SHOW_CREATED=" + _TRIM$(STR$(CFG.PALETTE_SHOW_CREATED%))
+    PRINT #fh%, "PALETTE_MENU_SHOW_CHIPS=" + _TRIM$(STR$(CFG.PALETTE_MENU_SHOW_CHIPS%))
     PRINT #fh%, "PALETTE_CREATE_MAX_COLORS=" + _TRIM$(STR$(CFG.PALETTE_CREATE_MAX_COLORS%))
     PRINT #fh%, ""
 

--- a/DRAW.cfg.default
+++ b/DRAW.cfg.default
@@ -188,6 +188,9 @@ PALETTE_SHOW_LOSPEC=1
 # Show user-created palettes in palette picker (1=yes, 0=no)
 PALETTE_SHOW_CREATED=1
 
+# Show color chips next to palette names in the palette dropdown menu (1=yes, 0=no)
+PALETTE_MENU_SHOW_CHIPS=1
+
 # Default max colors when creating palette from image (1-256)
 PALETTE_CREATE_MAX_COLORS=32
 

--- a/GUI/COMMAND.BM
+++ b/GUI/COMMAND.BM
@@ -4638,6 +4638,7 @@ SUB CMD_execute_action (action_id AS INTEGER)
             PALETTE_LOADER_COUNT% = 0
             PALETTE_LOADER_scan_folder "./ASSETS/PALETTES"
             PALETTE_LOADER_scan_user_folders
+            PALETTE_PREVIEW_invalidate_all ' List order changed — chip cache is index-keyed
             GUI_NEEDS_REDRAW% = TRUE
 
         CASE 1518 ' Toggle: Show Created palettes in picker
@@ -4647,8 +4648,15 @@ SUB CMD_execute_action (action_id AS INTEGER)
             PALETTE_LOADER_COUNT% = 0
             PALETTE_LOADER_scan_folder "./ASSETS/PALETTES"
             PALETTE_LOADER_scan_user_folders
+            PALETTE_PREVIEW_invalidate_all ' List order changed — chip cache is index-keyed
             GUI_NEEDS_REDRAW% = TRUE
-        
+
+        CASE 1519 ' Toggle: Show color chips in the palette dropdown menu
+            CFG.PALETTE_MENU_SHOW_CHIPS% = NOT CFG.PALETTE_MENU_SHOW_CHIPS%
+            CONFIG_save
+            GUI_NEEDS_REDRAW% = TRUE
+            SCENE_DIRTY%      = TRUE
+
         ' ========== TOOLS (menu-only) ==========
         CASE 1101 ' Capture Custom Brush (Ctrl+B) — was inline KEYBOARD_handle_custom_brush
             IF CUSTOM_BRUSH_is_active% THEN

--- a/GUI/MENUBAR.BM
+++ b/GUI/MENUBAR.BM
@@ -328,6 +328,7 @@ SUB MENUBAR_register_all ()
     MENUBAR_register_item "---", "", 7, 0, FALSE, TRUE
     MENUBAR_register_item "SHOW LOSPEC PALETTES", "", 7, 1517, TRUE, FALSE
     MENUBAR_register_item "SHOW CREATED PALETTES", "", 7, 1518, TRUE, FALSE
+    MENUBAR_register_item "SHOW COLOR CHIPS IN MENU", "", 7, 1519, TRUE, FALSE
 
     ' ========== IMAGE MENU (parentIdx = 8) ==========
     MENUBAR_register_item "FLIP CANVAS HORIZONTAL", "", 8, 1803, FALSE, FALSE
@@ -578,6 +579,8 @@ SUB MENUBAR_update_checkboxes ()
                     MENU_ITEMS(i%).checked% = CFG.PALETTE_SHOW_LOSPEC%
                 CASE 1518 ' Show Created palettes in picker
                     MENU_ITEMS(i%).checked% = CFG.PALETTE_SHOW_CREATED%
+                CASE 1519 ' Show color chips in the palette dropdown menu
+                    MENU_ITEMS(i%).checked% = CFG.PALETTE_MENU_SHOW_CHIPS%
                 CASE 603  ' Drawing Mode: Color
                     MENU_ITEMS(i%).checked% = (DRAWER.mode% = DRAWER_MODE_BRUSH)
                 CASE 604  ' Drawing Mode: Gradients

--- a/GUI/PALETTE-LOADER.BI
+++ b/GUI/PALETTE-LOADER.BI
@@ -29,4 +29,22 @@ DIM SHARED PALETTE_EMBEDDED_ACTIVE% ' TRUE when using embedded palette from DRW 
 ' 0=builtin ASSETS, 1=Lospec user download, 2=Created from image
 DIM SHARED PALETTE_LIST_SOURCE(0 TO 255) AS INTEGER
 
+' --- Palette color-chip preview cache (used by the palette dropdown menu) ---
+' Colors are parsed lazily, one palette at a time, the first time a menu row is
+' drawn — scanning every .GPL up front would stall startup on large Lospec sets.
+CONST PALETTE_PREVIEW_MAX_CHIPS   = 64  ' Hard cap on chips cached/drawn per palette
+CONST PALETTE_PREVIEW_CHIPS_PER_ROW = 32 ' Chips drawn per chip row (2 rows max)
+
+' State per palette index: 0 = not parsed yet, 1 = parsed OK, -1 = parse failed
+DIM SHARED PALETTE_PREVIEW_STATE(0 TO 255) AS INTEGER
+' Number of chips actually cached (0 .. PALETTE_PREVIEW_MAX_CHIPS)
+DIM SHARED PALETTE_PREVIEW_SHOWN(0 TO 255) AS INTEGER
+' Total colors found in the file (may exceed PALETTE_PREVIEW_MAX_CHIPS)
+DIM SHARED PALETTE_PREVIEW_TOTAL(0 TO 255) AS INTEGER
+DIM SHARED PALETTE_PREVIEW_COLORS(0 TO 255, 0 TO PALETTE_PREVIEW_MAX_CHIPS - 1) AS _UNSIGNED LONG
+
+' Per-frame budget so opening the menu never parses dozens of files in one frame
+DIM SHARED PALETTE_PREVIEW_BUDGET% ' Remaining parses allowed this frame
+DIM SHARED PALETTE_PREVIEW_PENDING% ' TRUE when rows were skipped and need another frame
+
 ' Declarations

--- a/GUI/PALETTE-LOADER.BM
+++ b/GUI/PALETTE-LOADER.BM
@@ -1203,3 +1203,141 @@ SUB PALETTE_LOADER_export_gpl (filepath AS STRING)
     _LOGINFO "PALETTE_LOADER_export_gpl: Exported " + _TRIM$(STR$(PAL_COLOR_COUNT%)) + " colors to " + filepath$
 END SUB
 
+
+''
+' Resolve a palette list entry to a full .GPL path.
+' Mirrors the built-in vs. user-path logic in PALETTE_LOADER_load_by_index.
+' @param idx INTEGER - Palette index in PALETTE_LIST
+' @return STRING - Full path, or "" when the entry has no file (separator rows)
+'
+FUNCTION PALETTE_PREVIEW_path$ (idx AS INTEGER)
+    DIM fn AS STRING
+    fn$ = RTRIM$(PALETTE_LIST(idx%).filename)
+    IF LEN(fn$) = 0 THEN
+        PALETTE_PREVIEW_path$ = ""
+        EXIT FUNCTION
+    END IF
+    IF LEFT$(fn$, 1) = "/" OR LEFT$(fn$, 2) = "./" OR LEFT$(fn$, 2) = ".\" OR MID$(fn$, 2, 2) = ":\" OR MID$(fn$, 2, 2) = ":/" THEN
+        PALETTE_PREVIEW_path$ = fn$
+    ELSE
+        PALETTE_PREVIEW_path$ = "./ASSETS/PALETTES/" + fn$
+    END IF
+END FUNCTION
+
+
+''
+' Drop every cached chip preview so the next menu render re-parses.
+' Call after the palette list is rebuilt or a .GPL is written/deleted.
+'
+SUB PALETTE_PREVIEW_invalidate_all ()
+    DIM i AS INTEGER
+    FOR i% = 0 TO UBOUND(PALETTE_PREVIEW_STATE)
+        PALETTE_PREVIEW_STATE(i%) = 0
+        PALETTE_PREVIEW_SHOWN(i%) = 0
+        PALETTE_PREVIEW_TOTAL(i%) = 0
+    NEXT i%
+END SUB
+
+
+''
+' Ensure the chip preview for one palette is cached, parsing its .GPL if needed.
+' Respects PALETTE_PREVIEW_BUDGET% so a single frame never parses more than a
+' handful of files; when the budget runs out PALETTE_PREVIEW_PENDING% is raised
+' and the caller is expected to request another frame.
+' @param idx INTEGER - Palette index in PALETTE_LIST
+' @return INTEGER - TRUE when colors are available for this index
+'
+FUNCTION PALETTE_PREVIEW_ensure% (idx AS INTEGER)
+    PALETTE_PREVIEW_ensure% = FALSE
+    IF idx% < 0 OR idx% > UBOUND(PALETTE_PREVIEW_STATE) THEN EXIT FUNCTION
+
+    IF PALETTE_PREVIEW_STATE(idx%) = 1 THEN
+        PALETTE_PREVIEW_ensure% = (PALETTE_PREVIEW_SHOWN(idx%) > 0)
+        EXIT FUNCTION
+    END IF
+    IF PALETTE_PREVIEW_STATE(idx%) = -1 THEN EXIT FUNCTION
+
+    ' Not parsed yet — spend a slice of this frame's budget
+    IF PALETTE_PREVIEW_BUDGET% <= 0 THEN
+        PALETTE_PREVIEW_PENDING% = TRUE
+        EXIT FUNCTION
+    END IF
+    PALETTE_PREVIEW_BUDGET% = PALETTE_PREVIEW_BUDGET% - 1
+
+    DIM path AS STRING
+    path$ = PALETTE_PREVIEW_path$(idx%)
+    IF LEN(path$) = 0 OR NOT _FILEEXISTS(path$) THEN
+        PALETTE_PREVIEW_STATE(idx%) = -1
+        EXIT FUNCTION
+    END IF
+
+    DIM ff      AS INTEGER
+    DIM lineIn  AS STRING
+    DIM i       AS INTEGER
+    DIM ch      AS STRING
+    DIM numStr  AS STRING
+    DIM numIdx  AS INTEGER
+    DIM rgb(0 TO 2) AS INTEGER
+    DIM total   AS INTEGER
+    DIM shown   AS INTEGER
+
+    total% = 0
+    shown% = 0
+    ff%    = FREEFILE
+    OPEN path$ FOR INPUT AS #ff%
+    DO WHILE NOT EOF(ff%)
+        LINE INPUT #ff%, lineIn$
+        lineIn$ = LTRIM$(RTRIM$(lineIn$))
+        IF LEN(lineIn$) = 0 THEN _CONTINUE
+        IF LEFT$(lineIn$, 1) = "#" THEN _CONTINUE
+        IF lineIn$ = "GIMP Palette" THEN _CONTINUE
+        IF LEFT$(lineIn$, 5) = "Name:" THEN _CONTINUE
+        IF LEFT$(lineIn$, 8) = "Columns:" THEN _CONTINUE
+
+        ' Parse "R G B [tab] Name" — take the first three integers on the line
+        numIdx% = 0
+        numStr$ = ""
+        FOR i% = 1 TO LEN(lineIn$)
+            ch$ = MID$(lineIn$, i%, 1)
+            IF ch$ >= "0" AND ch$ <= "9" THEN
+                numStr$ = numStr$ + ch$
+            ELSEIF ch$ = " " OR ch$ = CHR$(9) THEN
+                IF LEN(numStr$) > 0 THEN
+                    IF numIdx% < 3 THEN
+                        rgb%(numIdx%) = VAL(numStr$)
+                        numIdx%       = numIdx% + 1
+                    END IF
+                    numStr$ = ""
+                END IF
+                IF numIdx% = 3 THEN EXIT FOR
+            END IF
+        NEXT i%
+        IF LEN(numStr$) > 0 AND numIdx% < 3 THEN
+            rgb%(numIdx%) = VAL(numStr$)
+            numIdx%       = numIdx% + 1
+        END IF
+        IF numIdx% <> 3 THEN _CONTINUE
+
+        FOR i% = 0 TO 2
+            IF rgb%(i%) < 0 THEN rgb%(i%) = 0
+            IF rgb%(i%) > 255 THEN rgb%(i%) = 255
+        NEXT i%
+
+        total% = total% + 1
+        IF shown% < PALETTE_PREVIEW_MAX_CHIPS THEN
+            PALETTE_PREVIEW_COLORS(idx%, shown%) = _RGB32(rgb%(0), rgb%(1), rgb%(2))
+            shown%                               = shown% + 1
+        END IF
+    LOOP
+    CLOSE #ff%
+
+    PALETTE_PREVIEW_SHOWN(idx%) = shown%
+    PALETTE_PREVIEW_TOTAL(idx%) = total%
+    IF shown% > 0 THEN
+        PALETTE_PREVIEW_STATE(idx%) = 1
+        PALETTE_PREVIEW_ensure%     = TRUE
+    ELSE
+        PALETTE_PREVIEW_STATE(idx%) = -1
+    END IF
+END FUNCTION
+

--- a/GUI/PALETTE-STRIP.BI
+++ b/GUI/PALETTE-STRIP.BI
@@ -15,6 +15,14 @@ CONST PALETTE_STRIP_ARROW_WIDTH = 12
 ' PALETTE_STRIP_HEIGHT is now calculated dynamically based on palette size and config
 CONST PALETTE_MENU_MIN_WIDTH = 180 ' Minimum menu width for full names
 
+' Color-chip preview columns in the palette dropdown (CFG.PALETTE_MENU_SHOW_CHIPS)
+CONST PALETTE_MENU_NAME_COL_W  = 180 ' Width reserved for the palette name text
+CONST PALETTE_MENU_CHIP_W_MAX  = 4   ' Preferred chip width; shrinks to fit narrow screens
+CONST PALETTE_MENU_CHIP_H_MAX  = 4   ' Chip height cap so chips stay square, not tall ribbons
+CONST PALETTE_MENU_CHIP_W_MIN  = 2   ' Below this the chip column is dropped entirely
+CONST PALETTE_MENU_MORE_COL_W  = 76  ' Width reserved for the "...and N more" label
+CONST PALETTE_MENU_CHIP_GAP    = 4   ' Gap between the name column and the chips
+
 ' Palette menu state
 DIM SHARED PALETTE_MENU_VISIBLE%
 DIM SHARED PALETTE_MENU_X%

--- a/GUI/PALETTE-STRIP.BM
+++ b/GUI/PALETTE-STRIP.BM
@@ -292,9 +292,18 @@ SUB PALETTE_STRIP_render ()
     info_str$ = display_name$ + " " + CHR$(31)                                 ' Name + Down arrow
     _UPRINTSTRING (pal_name_x%, y% + (strip_height% \ 2) - 3), info_str$
     
-    ' Store menu position for dropdown (fixed width, extends left from right edge)
-    PALETTE_MENU_W% = PALETTE_MENU_MIN_WIDTH
+    ' Store menu position for dropdown (extends left from right edge; the chip
+    ' column widens the menu when CFG.PALETTE_MENU_SHOW_CHIPS is on)
+    DIM strip_chip_w AS INTEGER
+    strip_chip_w% = PALETTE_MENU_chip_w%
+    IF strip_chip_w% > 0 THEN
+        PALETTE_MENU_W% = PALETTE_MENU_NAME_COL_W + PALETTE_MENU_CHIP_GAP + _
+                          (PALETTE_PREVIEW_CHIPS_PER_ROW * strip_chip_w%) + PALETTE_MENU_MORE_COL_W
+    ELSE
+        PALETTE_MENU_W% = PALETTE_MENU_MIN_WIDTH
+    END IF
     PALETTE_MENU_X% = SCRN.w& - PALETTE_MENU_W% - 4
+    IF PALETTE_MENU_X% < 2 THEN PALETTE_MENU_X% = 2
     
     _FONT old_font&
 
@@ -618,6 +627,108 @@ END SUB
 
 
 ''
+' Width in pixels of one color chip in the palette dropdown.
+' Returns 0 when chips are disabled, or when the screen is too narrow to fit a
+' full 32-chip row at the minimum chip size (the menu then falls back to the
+' plain name-only layout).
+' @return INTEGER - Chip width in pixels, or 0 for "no chip column"
+'
+FUNCTION PALETTE_MENU_chip_w% ()
+    PALETTE_MENU_chip_w% = 0
+    IF NOT CFG.PALETTE_MENU_SHOW_CHIPS% THEN EXIT FUNCTION
+
+    DIM avail AS LONG
+    avail& = SCRN.w& - 8 - PALETTE_MENU_NAME_COL_W - PALETTE_MENU_CHIP_GAP - PALETTE_MENU_MORE_COL_W
+    IF avail& < PALETTE_PREVIEW_CHIPS_PER_ROW * PALETTE_MENU_CHIP_W_MIN THEN EXIT FUNCTION
+
+    DIM cw AS INTEGER
+    cw% = avail& \ PALETTE_PREVIEW_CHIPS_PER_ROW
+    IF cw% > PALETTE_MENU_CHIP_W_MAX THEN cw% = PALETTE_MENU_CHIP_W_MAX
+    PALETTE_MENU_chip_w% = cw%
+END FUNCTION
+
+
+''
+' Draw the color chip preview for one palette dropdown row.
+' Up to PALETTE_PREVIEW_MAX_CHIPS chips are drawn, PALETTE_PREVIEW_CHIPS_PER_ROW
+' across; palettes with more colors than fit get an "...and N more" label.
+' Colors come from the live PAL() array for the active palette, from
+' PALETTE_DOC_COLORS for the [DOCUMENT] row, and from the lazily-parsed
+' PALETTE_PREVIEW_* cache for everything else.
+'
+' @param idx INTEGER Palette index, or -2 for the [DOCUMENT] row
+' @param chipX INTEGER Left X of the chip column
+' @param rowY INTEGER Top Y of the menu row
+' @param rowH INTEGER Height of the menu row
+' @param chipW INTEGER Chip width in pixels (from PALETTE_MENU_chip_w%)
+' @param labelFg _UNSIGNED LONG Text color for the "...and N more" label
+'
+SUB PALETTE_MENU_draw_chips (idx AS INTEGER, chipX AS INTEGER, rowY AS INTEGER, rowH AS INTEGER, chipW AS INTEGER, labelFg AS _UNSIGNED LONG)
+    IF chipW% < 1 THEN EXIT SUB
+
+    DIM chips(0 TO PALETTE_PREVIEW_MAX_CHIPS - 1) AS _UNSIGNED LONG
+    DIM shown AS INTEGER, total AS INTEGER, i AS INTEGER
+    shown% = 0
+    total% = 0
+
+    IF idx% = -2 THEN
+        ' [DOCUMENT] row — colors snapshotted from the loaded .draw file
+        total% = PALETTE_DOC_COUNT%
+        shown% = total%
+        IF shown% > PALETTE_PREVIEW_MAX_CHIPS THEN shown% = PALETTE_PREVIEW_MAX_CHIPS
+        FOR i% = 0 TO shown% - 1
+            chips~&(i%) = PALETTE_DOC_COLORS(i%)
+        NEXT i%
+    ELSEIF idx% = PALETTE_LOADER_CURRENT_IDX% AND NOT PALETTE_EMBEDDED_ACTIVE% THEN
+        ' Active palette — read live so palette edits show up immediately
+        total% = PAL_COLOR_COUNT%
+        shown% = total%
+        IF shown% > PALETTE_PREVIEW_MAX_CHIPS THEN shown% = PALETTE_PREVIEW_MAX_CHIPS
+        FOR i% = 0 TO shown% - 1
+            chips~&(i%) = PAL(i%).value~&
+        NEXT i%
+    ELSE
+        IF NOT PALETTE_PREVIEW_ensure%(idx%) THEN EXIT SUB
+        shown% = PALETTE_PREVIEW_SHOWN(idx%)
+        total% = PALETTE_PREVIEW_TOTAL(idx%)
+        FOR i% = 0 TO shown% - 1
+            chips~&(i%) = PALETTE_PREVIEW_COLORS(idx%, i%)
+        NEXT i%
+    END IF
+
+    IF shown% < 1 THEN EXIT SUB
+
+    ' One chip row up to 32 colors, a second stacked row beyond that
+    DIM chipRows AS INTEGER, chipH AS INTEGER
+    IF shown% > PALETTE_PREVIEW_CHIPS_PER_ROW THEN chipRows% = 2 ELSE chipRows% = 1
+    chipH% = (rowH% - 2) \ chipRows%
+    IF chipH% > PALETTE_MENU_CHIP_H_MAX THEN chipH% = PALETTE_MENU_CHIP_H_MAX
+    IF chipH% < 1 THEN chipH% = 1
+
+    ' Center the chip block vertically in the row
+    DIM chipTop AS INTEGER
+    chipTop% = rowY% + ((rowH% - (chipRows% * chipH%)) \ 2)
+
+    DIM cx AS INTEGER, cy AS INTEGER, col AS INTEGER, rw AS INTEGER
+    FOR i% = 0 TO shown% - 1
+        col% = i% MOD PALETTE_PREVIEW_CHIPS_PER_ROW
+        rw%  = i% \ PALETTE_PREVIEW_CHIPS_PER_ROW
+        cx%  = chipX% + (col% * chipW%)
+        cy%  = chipTop% + (rw% * chipH%)
+        LINE (cx%, cy%)-(cx% + chipW% - 1, cy% + chipH% - 1), chips~&(i%), BF
+    NEXT i%
+
+    ' Emphasize that the palette has colors the preview could not show
+    IF total% > shown% THEN
+        DIM moreLbl AS STRING
+        moreLbl$ = "...and " + _TRIM$(STR$(total% - shown%)) + " more"
+        COLOR labelFg~&, _RGBA32(0, 0, 0, 0)
+        _UPRINTSTRING (chipX% + (PALETTE_PREVIEW_CHIPS_PER_ROW * chipW%) + 4, rowY% + 2), moreLbl$
+    END IF
+END SUB
+
+
+''
 ' Render palette selection dropdown menu
 '
 SUB PALETTE_MENU_render ()
@@ -638,6 +749,14 @@ SUB PALETTE_MENU_render ()
     hover_bg~& = THEME.PALETTE_MENU_hover_bg~&
     sel_bg~&   = THEME.PALETTE_MENU_selected_bg~&
     
+    ' Chip column geometry — chip_w = 0 means the name-only layout
+    DIM chip_w AS INTEGER, chip_x AS INTEGER
+    chip_w% = PALETTE_MENU_chip_w%
+    chip_x% = PALETTE_MENU_X% + PALETTE_MENU_NAME_COL_W + PALETTE_MENU_CHIP_GAP
+    ' Budget the .GPL parsing so one frame never stalls on dozens of files
+    PALETTE_PREVIEW_BUDGET%  = 8
+    PALETTE_PREVIEW_PENDING% = FALSE
+
     visible_count% = PALETTE_LOADER_COUNT%
     ' Reserve 1 row for [DOCUMENT] entry + separator when it exists
     DIM doc_rows_reserved AS INTEGER
@@ -677,6 +796,7 @@ SUB PALETTE_MENU_render ()
             COLOR fg_color~&, _RGBA32(0, 0, 0, 0)
         END IF
         _UPRINTSTRING (PALETTE_MENU_X% + 4, doc_y% + 2), "[DOCUMENT]"
+        IF chip_w% > 0 THEN PALETTE_MENU_draw_chips -2, chip_x%, doc_y%, menu_item_h%, chip_w%, fg_color~&
         ' Separator line below [DOCUMENT]
         DIM doc_sep_y      AS INTEGER
         doc_sep_y% = doc_y% + menu_item_h%
@@ -755,6 +875,8 @@ SUB PALETTE_MENU_render ()
                 display_name$ = LEFT$(display_name$, 31) + "..."
             END IF
             _UPRINTSTRING (PALETTE_MENU_X% + 4, y% + 2), display_name$
+
+            IF chip_w% > 0 THEN PALETTE_MENU_draw_chips item_idx%, chip_x%, y%, menu_item_h%, chip_w%, fg_color~&
         END IF
     NEXT i%
     
@@ -770,6 +892,14 @@ SUB PALETTE_MENU_render ()
     END IF
     
     _FONT old_font&
+
+    ' Some rows hit the per-frame parse budget — ask for another frame so their
+    ' chips fill in instead of staying blank until the next unrelated redraw
+    IF PALETTE_PREVIEW_PENDING% THEN
+        GUI_NEEDS_REDRAW% = TRUE
+        SCENE_DIRTY%      = TRUE
+        FRAME_IDLE%       = FALSE
+    END IF
 
     ' Play hover sound when menu item changes
     IF (PALETTE_MENU_HOVER% >= 0 OR PALETTE_MENU_HOVER% = -2) AND PALETTE_MENU_HOVER% <> PALETTE_MENU_PREV_HOVER% THEN

--- a/PLANS/IDEAS.md
+++ b/PLANS/IDEAS.md
@@ -1,15 +1,21 @@
 # IDEAS
 
-## Add color chips to popup palettes menu
-- [ ] It would be great if the actual palette chips were rendered in the palette picker popup menu
-  - [ ] Add a setting to enable this or disable it
-  - [ ] Maximum 64 chips in 32 chips across rows
-    - [ ] Optimize chip rows to be divisible by 8 
-      - [ ] If 8 colors - 1 row
-      - [ ] If 16 colors - 1 row (less than 32)
-      - [ ] If 24 colors - 1 row
-      - [ ] If 32 colors - 1 row
-      - [ ] More than 32 colors - second row but up to 64 total displayed with a "...and # more" to emphasize there are more colors displayed and # is the number of chips that aren't displayed.
+## Add color chips to popup palettes menu — DONE (v1.6.0+)
+- [x] It would be great if the actual palette chips were rendered in the palette picker popup menu
+  - [x] Add a setting to enable this or disable it
+        (`PALETTE_MENU_SHOW_CHIPS` in DRAW.cfg, PALETTE > SHOW COLOR CHIPS IN MENU, action 1519)
+  - [x] Maximum 64 chips in 32 chips across rows
+    - [x] Optimize chip rows to be divisible by 8 
+      - [x] If 8 colors - 1 row
+      - [x] If 16 colors - 1 row (less than 32)
+      - [x] If 24 colors - 1 row
+      - [x] If 32 colors - 1 row
+      - [x] More than 32 colors - second row but up to 64 total displayed with a "...and # more" to emphasize there are more colors displayed and # is the number of chips that aren't displayed.
+- Implementation: chips render inline to the right of the palette name at 4x4px,
+  so the dropdown's fixed row height / hit-test / scroll math is unchanged.
+  Colors come from `PALETTE_PREVIEW_*` in GUI/PALETTE-LOADER.BM — a lazily-parsed,
+  index-keyed cache with an 8-files-per-frame budget so opening the menu never
+  stalls on a large Lospec collection.
 
 ## AI Integration
 - [ ] Add support for AI image generation


### PR DESCRIPTION
## Summary

Each row in the palette selection dropdown now previews the palette's actual colors as 4x4 chips drawn **inline to the right of the name**, 32 per chip row and up to 64 chips total. Palettes with more colors than fit get an `...and N more` label.

Implements the `PLANS/IDEAS.md` entry "Add color chips to popup palettes menu".

## Design notes

- **Inline layout** was chosen over stacking chips under the name so the dropdown's fixed row height, hit-testing, scrolling and keyboard navigation are all completely unchanged — the only structural change is the menu's width.
- Colors come from a new lazily-parsed, index-keyed cache (`PALETTE_PREVIEW_*` in `GUI/PALETTE-LOADER.BM`) with a tri-state per entry, so a missing or malformed `.GPL` is parsed once and never retried.
- Parsing is budgeted to 8 files per frame and requests a follow-up frame when rows are deferred, so opening the menu over a large Lospec collection cannot stall a single `SCREEN_render`.
- The active palette and the `[DOCUMENT]` row read live colors (`PAL()` / `PALETTE_DOC_COLORS`) instead of the cache, so palette edits show up immediately.
- The chip column widens the menu and shrinks the chip size on narrow screens, falling back to the name-only layout when even minimum-size chips won't fit.
- Toggling SHOW LOSPEC / SHOW CREATED rebuilds the palette list and therefore invalidates the index-keyed cache.

## Setting

Toggle via **PALETTE > SHOW COLOR CHIPS IN MENU** (action 1519), persisted as `PALETTE_MENU_SHOW_CHIPS` in `DRAW.cfg`. Defaults to on.

## Test plan

- [x] Compiles clean with QB64-PE 4.5.0
- [x] Verified visually in the running app by @grymmjack — chips render for built-in, Lospec and created palettes
- [x] Chip size tuned from 8px to 4px so the dropdown isn't overly wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)