### PR TITLE
Fix dropdown mouse-wheel scroll snapping back to the selection

### DIFF
--- a/GUI/DIALOG.BM
+++ b/GUI/DIALOG.BM
@@ -414,13 +414,16 @@ SUB DIALOG_dropdown_input (ctx AS DIALOG_CTX)
     ' --- keyboard: only while open, so the dialog's own _KEYHIT (Enter=OK,
     '     Esc=Cancel) never fires on the same keystroke that drives the list ---
     DIM kk AS LONG : kk& = _KEYHIT
+    DIM arrowMoved AS INTEGER : arrowMoved% = FALSE
     SELECT CASE kk&
         CASE 18432 ' Up
             DIALOG_DD_SEL% = DIALOG_DD_SEL% - 1
             IF DIALOG_DD_SEL% < 0 THEN DIALOG_DD_SEL% = 0
+            arrowMoved% = TRUE
         CASE 20480 ' Down
             DIALOG_DD_SEL% = DIALOG_DD_SEL% + 1
             IF DIALOG_DD_SEL% > DIALOG_DD_COUNT% - 1 THEN DIALOG_DD_SEL% = DIALOG_DD_COUNT% - 1
+            arrowMoved% = TRUE
         CASE 13 ' Enter -> commit highlighted row
             DIALOG_DD_RESULT_ID%  = DIALOG_DD_OPEN%
             DIALOG_DD_RESULT_VAL% = DIALOG_DD_SEL%
@@ -428,9 +431,13 @@ SUB DIALOG_dropdown_input (ctx AS DIALOG_CTX)
         CASE 27 ' Esc -> dismiss (no change)
             DIALOG_DD_OPEN% = 0
     END SELECT
-    ' keep the highlighted row in view after an arrow move
-    IF DIALOG_DD_SEL% < DIALOG_DD_SCROLL% THEN DIALOG_DD_SCROLL% = DIALOG_DD_SEL%
-    IF DIALOG_DD_SEL% > DIALOG_DD_SCROLL% + vis% - 1 THEN DIALOG_DD_SCROLL% = DIALOG_DD_SEL% - vis% + 1
+    ' Auto-scroll the highlighted row into view ONLY on an arrow move — NOT every
+    ' frame, or it would immediately undo a mouse-wheel scroll (snapping the list
+    ' back so the selected item, under the pointer, stays visible).
+    IF arrowMoved% THEN
+        IF DIALOG_DD_SEL% < DIALOG_DD_SCROLL% THEN DIALOG_DD_SCROLL% = DIALOG_DD_SEL%
+        IF DIALOG_DD_SEL% > DIALOG_DD_SCROLL% + vis% - 1 THEN DIALOG_DD_SCROLL% = DIALOG_DD_SEL% - vis% + 1
+    END IF
 
     IF ctx.mwheel <> 0 AND DIALOG_DD_COUNT% > DIALOG_DD_MAXVIS% THEN
         DIALOG_DD_SCROLL% = DIALOG_DD_SCROLL% + ctx.mwheel

--- a/QA/tests/effect-dropdown-wheel.sh
+++ b/QA/tests/effect-dropdown-wheel.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# =============================================================================
+# effect-dropdown-wheel.sh — QA test / regression guard
+#
+# The shared dialog DROPDOWN must SCROLL with the mouse wheel while open (fixed
+# 2026-08-16). The bug: DIALOG_dropdown_input auto-scrolled the highlighted
+# (selected) row into view EVERY frame, so a wheel scroll was undone on the very
+# next frame — the list snapped back so the selected item (under the pointer)
+# stayed visible and you could never scroll away from it. Now the auto-follow
+# only runs on an arrow-key move, leaving the wheel free.
+#
+# Posterize's dither dropdown has 23 items (> the 8 visible), so it scrolls. We
+# open it, snapshot a strip of the OPEN list, wheel DOWN a few times over the
+# list, and snapshot the same strip: with the fix the list scrolled so the strip
+# shows different labels (differ); with the bug it snaps back (identical).
+#
+# Posterize opened via the command palette; dither dropdown box ~ (478,311).
+# =============================================================================
+
+info "=== Dropdown Mouse-Wheel Scroll Test ==="
+
+canvas_focus b
+wait_for 0.3 "Brush ready"
+for n in 1 2 3 4 5 6; do key bracketright; done
+CHIP_Y=$(( VIEWPORT_H - STATUS_H - 6 ))
+click $(( 16 + 5*17 + 8 )) "$CHIP_Y" ; wait_for 0.2 "A colour"
+drag $(( CANVAS_CX - 60 )) "$CANVAS_CY" $(( CANVAS_CX + 60 )) "$CANVAS_CY"
+key grave
+wait_for 0.3 "Content drawn"
+assert_no_crash
+
+# Open Posterize and its dither dropdown.
+key question ; wait_for 0.5 "Command palette"
+type_text "Posterize" ; wait_for 0.5 "Filtered"
+key Return ; wait_for 0.7 "Posterize dialog open"
+click 478 311 ; wait_for 0.4 "Dither dropdown open"
+screenshot "dd-wheel-open"
+
+# Snapshot a strip across the top rows of the OPEN list.
+LX=380; LY=330; LW=180; LH=54
+park_mouse
+snap_region "$LX" "$LY" "$LW" "$LH" "dd-wheel-before"
+BEFORE="$SNAP_RESULT"
+
+# Wheel down over the list — should scroll it (not snap back to the selection).
+scroll_down 470 362
+scroll_down 470 362
+scroll_down 470 362
+scroll_down 470 362
+wait_for 0.3 "Wheeled the list down"
+screenshot "dd-wheel-scrolled"
+
+park_mouse
+snap_region "$LX" "$LY" "$LW" "$LH" "dd-wheel-after"
+AFTER="$SNAP_RESULT"
+
+assert_regions_differ "$BEFORE" "$AFTER" \
+    "Mouse wheel must scroll the open dropdown list (must not snap back to the selection)"
+assert_no_crash
+assert_window_exists
+info "=== Dropdown Mouse-Wheel Scroll Test PASSED ==="


### PR DESCRIPTION
**Bug (reported by @grymmjack):** In the Blend Last Effect dialog (and any dialog using the shared dropdown), the mouse wheel couldn't scroll the open list — it kept resetting to the item under the pointer.

**Cause:** `DIALOG_dropdown_input`'s "keep the highlighted row in view" clamp ran *every frame*, so a wheel scroll was undone on the very next frame — the list snapped back so the selected item (which sits under the pointer) stayed visible.

**Fix:** the auto-follow now runs **only on an arrow-key move**, leaving the wheel free to scroll the list independently. Arrow-key navigation and selection commit are unchanged.

Affects every dropdown: Blend Last Effect (19 modes), Posterize dither (23), Mosaic shape, Stone type, Lens Flare lens.

**Testing:** new `QA/tests/effect-dropdown-wheel.sh` opens the dither dropdown, wheels down, and asserts the visible list rows changed (this fails on the pre-fix snap-back). Arrow-nav dropdown tests (`posterize-dither-color`, `effect-mosaic-shapes`, `effect-redo-last`) still 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)