### PR TITLE
fix: clicking outside a paste/move float deselects it (no re-stamp) + Edit-menu Deselect

### DIFF
--- a/GUI/MENUBAR.BM
+++ b/GUI/MENUBAR.BM
@@ -201,6 +201,9 @@ SUB MENUBAR_register_all ()
     MENUBAR_register_item "UNDO", "Ctrl+Z", 1, 301, FALSE, FALSE
     MENUBAR_register_item "REDO", "Ctrl+Y", 1, 302, FALSE, FALSE
     MENUBAR_register_item "---", "", 1, 0, FALSE, TRUE
+    MENUBAR_register_item "SELECT ALL", "Ctrl+A", 1, 310, FALSE, FALSE
+    MENUBAR_register_item "DESELECT", "Ctrl+D", 1, 307, FALSE, FALSE
+    MENUBAR_register_item "---", "", 1, 0, FALSE, TRUE
     MENUBAR_register_item "CUT", "Ctrl+X", 1, 304, FALSE, FALSE
     MENUBAR_register_item "COPY", "Ctrl+C", 1, 303, FALSE, FALSE
     MENUBAR_register_item "COPY MERGED", "Ctrl+Shift+C", 1, 322, FALSE, FALSE

--- a/INPUT/MOUSE.BM
+++ b/INPUT/MOUSE.BM
@@ -2193,14 +2193,21 @@ SUB MOUSE_tool_move ()
                 ' Start moving from center (handle 0)
                 MOVE_start_transform 0, MOUSE.UNSNAPPED_X%, MOUSE.UNSNAPPED_Y%
             ELSE
-                ' Clicking outside the selection commits the move (standard UX pattern
-                ' matching Photoshop, GIMP, Krita). Without this, the transform stays
-                ' floating indefinitely and no undo state is created until tool switch.
+                ' Clicking outside the float FINALIZES it (commits the move; a paste
+                ' composites exactly once via MOVE_reset, which honors IS_PASTE) and
+                ' DESELECTS — the same click-to-deselect the marquee tools give, and
+                ' the standard Photoshop/GIMP/Krita pattern.
+                '
+                ' It used to re-capture a NEW float at the click and start transforming
+                ' it, which left a float "live" after the click: a subsequent drag then
+                ' re-stamped it across the canvas (TempodiBasic 2.0.3 report — "these
+                ' lasts stamps on the pictures", and no obvious way to null the
+                ' selection). Dropping it here ends the float cleanly; the next fresh
+                ' click (MOVE not active) captures new content to move.
                 MOVE_reset
-                ' Now start a fresh capture at the clicked position so user can
-                ' immediately begin a new move operation
-                MOVE_capture_selection
-                MOVE_start_transform 0, MOUSE.UNSNAPPED_X%, MOUSE.UNSNAPPED_Y%
+                MARQUEE_clear
+                MAGIC_WAND_reset
+                INVALIDATE_scene
             END IF
         ELSE
             ' Update transform while dragging

--- a/PLANS/_/BUGS.md
+++ b/PLANS/_/BUGS.md
@@ -1,5 +1,21 @@
 # BUGS
 
+## Clicking outside a paste/move float re-stamps instead of deselecting (FIXED 2026-09-06)
+- [x] TempodiBasic 2.0.3 report: after copy/paste (a float), clicking outside the
+      selection then dragging re-stamped the content ("these lasts stamps on the
+      pictures"), and there was no obvious way to null the selection.
+  - [x] Root cause: the MOVE tool's click-outside branch committed the float then
+        IMMEDIATELY re-captured + started transforming a NEW float, so it stayed
+        "live" — a subsequent drag moved/stamped it (INPUT/MOUSE.BM, MOVE press).
+  - [x] Fix: on a click outside the float, FINALIZE it once (MOVE_reset, honors
+        IS_PASTE) and DESELECT (MARQUEE_clear + MAGIC_WAND_reset + INVALIDATE_scene),
+        matching the marquee tools' click-to-deselect. No re-grab.
+  - [x] Discoverability: added "SELECT ALL" (Ctrl+A) and "DESELECT" (Ctrl+D) to the
+        Edit menu (GUI/MENUBAR.BM) — they existed only as hotkeys / command palette.
+  - [x] Regression test QA/tests/float-click-outside-deselect.sh (floats a block,
+        clicks+drags outside; pre-fix the content is dragged away, post-fix it stays).
+        Deselect answer for the reporter: Ctrl+D or Esc.
+
 ## Line tool pressing s and e does not change caps, but switches tools instead
 - [x] While drawing with line tool and in active drag state:
   - [x] Pressing s changes to smart shape

--- a/QA/tests/float-click-outside-deselect.sh
+++ b/QA/tests/float-click-outside-deselect.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# =============================================================================
+# float-click-outside-deselect.sh — clicking OUTSIDE a floating selection must
+# FINALIZE it and DESELECT, not re-grab a new float.
+#
+# TempodiBasic 2.0.3 report: after copy/paste (a float), clicking outside the
+# selection then dragging re-stamped the content ("these lasts stamps on the
+# pictures"), and there was no obvious way to null the selection. The MOVE tool's
+# click-outside branch used to commit the float then IMMEDIATELY re-capture and
+# start transforming a NEW float, so a float stayed "live" after the click and a
+# subsequent drag moved/stamped it. The fix drops it (MOVE_reset + MARQUEE_clear +
+# MAGIC_WAND_reset), matching the marquee tools' click-to-deselect.
+#
+# This uses a MOVE float, which goes through the exact same click-outside branch a
+# paste float uses (the IS_PASTE difference only changes how MOVE_reset composites,
+# not the re-grab-vs-drop behavior). It floats a magenta block, then does ONE drag
+# gesture that STARTS OUTSIDE the float:
+#   pre-fix  -> re-grabs the float and drags the content away from centre (centre changes)
+#   post-fix -> drops the float, so the content stays put (centre unchanged)
+# =============================================================================
+
+info "=== Float click-outside deselect Test ==="
+
+canvas_focus b
+wait_for 0.3 "Brush ready"
+for n in 1 2 3 4 5 6 7 8; do key bracketright; done
+wait_for 0.2 "Brush enlarged"
+
+# -- Magenta block at centre (same palette chip as selection-rotate-float) -----
+CHIP_Y=$(( VIEWPORT_H - STATUS_H - 6 ))
+click $(( 16 + 25*17 + 8 )) "$CHIP_Y" ; wait_for 0.3 "Magenta"
+for dy in -40 -24 -8 8 24 40; do
+  drag $(( CANVAS_CX - 65 )) $(( CANVAS_CY + dy )) $(( CANVAS_CX + 65 )) $(( CANVAS_CY + dy ))
+  wait_for 0.1 "stroke"
+done
+key grave
+wait_for 0.1 "Pointer hidden"
+park_mouse
+wait_for 0.3 "Block drawn"
+assert_no_crash
+
+# -- Marquee-select a big sub-rect (leaves clear margins to click OUTSIDE) ------
+key m
+wait_for 0.5 "Marquee tool"
+drag $(( CANVAS_CX - 55 )) $(( CANVAS_CY - 40 )) $(( CANVAS_CX + 55 )) $(( CANVAS_CY + 40 ))
+wait_for 0.5 "Selection made"
+
+# -- Float it: Move tool, bare click INSIDE the selection to grab (no move) -----
+key v
+wait_for 0.4 "Move tool"
+click $CANVAS_CX $CANVAS_CY
+wait_for 0.4 "Float grabbed"
+assert_no_crash
+
+# -- Snap the float's location (centre) BEFORE the outside gesture. The region
+#    sits FULLY inside the selection, so if a re-grabbed float lifts+moves the
+#    centre content the whole region changes (well past the ~same tolerance). ---
+park_mouse
+CEN_X=$(( CANVAS_CX - 35 )) ; CEN_Y=$(( CANVAS_CY - 25 )) ; CEN_W=70 ; CEN_H=50
+snap_region "$CEN_X" "$CEN_Y" "$CEN_W" "$CEN_H" "float-center-before"
+BEFORE="$SNAP_RESULT"
+
+# -- ONE gesture: press + drag STARTING OUTSIDE the float, moving it clear of
+#    the centre. Pre-fix this re-grabs and drags the centre content away (centre
+#    empties); post-fix the float is dropped, so nothing moves. -----------------
+drag $(( CANVAS_CX - 90 )) $(( CANVAS_CY - 70 )) $(( CANVAS_CX - 30 )) $(( CANVAS_CY - 10 ))
+wait_for 0.5 "Clicked/dragged outside the float"
+assert_no_crash
+
+park_mouse
+snap_region "$CEN_X" "$CEN_Y" "$CEN_W" "$CEN_H" "float-center-after"
+AFTER="$SNAP_RESULT"
+
+# Clicking outside must drop the float (content stays), NOT re-grab and drag it.
+assert_regions_same "$BEFORE" "$AFTER" \
+  "Clicking outside a float must finalize+deselect it, not re-grab and drag the content"
+
+screenshot "float-click-outside-deselect"
+assert_no_crash
+assert_window_exists
+info "=== Float click-outside deselect Test COMPLETE ==="


### PR DESCRIPTION
Fixes the paste-float issue from TempodiBasic's DRAW 2.0.3 field report.

## Problem
After copy/paste (a floating selection), clicking outside the selection and then dragging **re-stamped** the content across the canvas ("these lasts stamps on the pictures"), and there was no obvious way to null the selection.

The Move tool's click-outside branch committed the float but then **immediately re-captured a NEW float at the click and started transforming it**, so a float stayed "live" after the click — a subsequent drag moved/stamped it.

## Fix
On a click outside the float, **finalize it once** (`MOVE_reset`, which honors `IS_PASTE` and composites a paste exactly once) and **deselect** (`MARQUEE_clear` + `MAGIC_WAND_reset` + `INVALIDATE_scene`) — matching the marquee tools' click-to-deselect, and the standard Photoshop/GIMP/Krita pattern. No re-grab; the next fresh click captures new content to move.

## Discoverability
The tester couldn't find how to clear a selection. **Deselect (Ctrl+D)** and **Select All (Ctrl+A)** existed only as hotkeys / command-palette entries — added both to the **Edit menu** with their shortcuts shown (both actions were already dispatched in `CMD_execute_action`).

## Test
New `QA/tests/float-click-outside-deselect.sh`: floats a block, then does one drag gesture starting *outside* the float.
- pre-fix → re-grabs and drags the content away from centre (1742px change, exceeds tolerance) → **fails**
- post-fix → the float is dropped, content stays put → **passes**

Verified fail-pre-fix / pass-post-fix; `selection-rotate-float` and `edit-copy-paste` show no regressions.

Independent of #107 (different code regions). Deselect answer for the reporter: **Ctrl+D or Esc**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)