### PR TITLE
fix(grid): re-init grid image on New / New-from-* (gotcha #15)

### DIFF
--- a/GUI/GRID.BM
+++ b/GUI/GRID.BM
@@ -71,8 +71,36 @@ END SUB
 
 
 ''
+' GRID_reinit_preserve — recreate the grid image at the CURRENT canvas size while
+' keeping the current grid settings (size, mode, visibility, cell-fill, align).
+'
+' For the New / New-from-Clipboard / New-from-AI document paths. GRID_init sizes
+' the grid image to SCRN.canvasW/H, so it MUST run after the new canvas size is
+' set. Unlike Open (which restores the loaded FILE's grid), New keeps whatever
+' grid the user currently has. Fixes a stale grid image kept from a prior Crop
+' that the zoom _PUTIMAGE then stretched into thick edge bands — gotcha #15, the
+' doc-creation paths had drifted (only Open re-init'd the grid).
+'
+SUB GRID_reinit_preserve ()
+    DIM sShow AS INTEGER, sSnap AS INTEGER, sMode AS INTEGER, sFill AS INTEGER
+    DIM sAlign AS INTEGER, sGW AS INTEGER, sGH AS INTEGER, sPixShow AS INTEGER
+    sShow%  = GRID.SHOW%      : sSnap% = GRID.SNAP%      : sMode% = GRID.GRID_MODE%
+    sFill%  = GRID.CELL_FILL% : sAlign% = GRID.ALIGN_MODE%
+    sGW%    = GRID.gridWidth% : sGH%   = GRID.gridHeight%
+    sPixShow% = PIXEL_GRID.SHOW%
+    GRID_init                      ' recreates image at SCRN.canvasW/H; resets ssCache + settings
+    GRID.SHOW%       = sShow%  : GRID.SNAP%      = sSnap%  : GRID.GRID_MODE% = sMode%
+    GRID.CELL_FILL%  = sFill%  : GRID.ALIGN_MODE% = sAlign%
+    GRID.gridWidth%  = sGW%    : GRID.gridHeight% = sGH%
+    GRID_draw                      ' redraw with the restored settings
+    PIXEL_GRID_init
+    PIXEL_GRID.SHOW% = sPixShow%
+END SUB
+
+
+''
 ' Draw grid
-' 
+'
 SUB GRID_draw ()
     ' Safety: prevent infinite loop if grid size is somehow 0
     IF GRID.gridWidth% < 1 THEN GRID.gridWidth% = 10

--- a/QA/tests/grid-reinit-on-new-source-guards.sh
+++ b/QA/tests/grid-reinit-on-new-source-guards.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# =============================================================================
+# grid-reinit-on-new-source-guards.sh — QA regression guard (SOURCE-level)
+#
+# Guards gotcha #15: all THREE document-creation paths must recreate the grid
+# image for the new canvas size. They had DRIFTED — only Open (DRW_load_binary)
+# re-init'd the grid, so New / New-from-* kept a stale grid image (e.g. the small
+# one left by a prior Crop), which the zoom _PUTIMAGE then stretched into thick
+# solid bands along the top row + left column.
+#
+# WHY source-level: reproducing the exact crop -> New-from-template -> zoom flow
+# offscreen is unreliable (crop action, grid visibility, zoom keys, template
+# picker). This test asserts the fix's marker — GRID_reinit_preserve called from
+# both New paths — is still present, so a refactor can't silently delete it.
+# =============================================================================
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/source-guard.sh"
+
+echo "=== Grid re-init on document creation source guards ==="
+
+# The shared helper exists and preserves the current grid across the re-init.
+assert_grep "HELPER" "GUI/GRID.BM" 'SUB GRID_reinit_preserve'          "grid re-init helper exists"
+assert_grep "HELPER" "GUI/GRID.BM" 'GRID_init'                         "helper recreates the grid image (GRID_init)"
+assert_grep "HELPER" "GUI/GRID.BM" 'GRID\.gridWidth%  *= *sGW%'        "helper restores the current grid size"
+
+# Both New paths call it (Open already re-inits via GRID_init directly).
+assert_grep "NEW"    "TOOLS/DRW.BM" 'GRID_reinit_preserve'             "a New path calls the helper"
+# Exactly the two New subs must call it — verify the count is 2 (new_canvas +
+# create_canvas_at_size), so neither path can silently drop the re-init again.
+_ng=$(grep -c 'GRID_reinit_preserve' "$ROOT/TOOLS/DRW.BM" 2>/dev/null)
+if [ "${_ng:-0}" -ge 2 ]; then pass "NEW: both New paths call GRID_reinit_preserve (${_ng})"; else fail "NEW: expected >=2 GRID_reinit_preserve calls in DRW.BM, found ${_ng:-0}"; fi
+
+# Open still re-inits the grid (regression guard on the path that was already correct).
+assert_grep "OPEN"   "TOOLS/DRW.BM" 'GRID_init'                        "Open (DRW_load_binary) re-inits the grid"
+
+guard_footer "a document-creation path stopped recreating the grid image (gotcha #15)"
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then [ "$fails" -eq 0 ] && exit 0 || exit 1; fi

--- a/TOOLS/DRW.BM
+++ b/TOOLS/DRW.BM
@@ -2471,6 +2471,12 @@ SUB DRW_new_canvas ()
     ' === RESET CANVAS DIMENSIONS TO USER-SPECIFIED SIZE ===
     SCRN.canvasW& = newCanvasW%
     SCRN.canvasH& = newCanvasH%
+    ' Recreate the grid image at the new canvas size, preserving the current grid.
+    ' gotcha #15: Open (DRW_load_binary) re-inits the grid, but New / New-from-*
+    ' had drifted and kept the OLD grid image — a prior Crop's small image then got
+    ' stretched into thick edge bands by the zoom _PUTIMAGE. Safe here: it only
+    ' needs SCRN.canvasW/H, which are now set.
+    GRID_reinit_preserve
     SCREEN_pattern_tile_force_off
 
     ' === RECREATE PAINTING BUFFER AT CANVAS SIZE ===
@@ -2663,6 +2669,9 @@ SUB DRW_create_canvas_at_size (canvasW AS INTEGER, canvasH AS INTEGER)
     ' === SET CANVAS DIMENSIONS ===
     SCRN.canvasW& = ncW%
     SCRN.canvasH& = ncH%
+    ' Recreate the grid image at the new canvas size, preserving the current grid
+    ' (gotcha #15 — same drift the New path had; see GRID_reinit_preserve).
+    GRID_reinit_preserve
     SCREEN_pattern_tile_force_off
 
     ' === RECREATE PAINTING BUFFER ===


### PR DESCRIPTION
## Bug
At zoom, the grid's **first row + column render as thick solid bands** after a Crop-to-small followed by New / New-from-template (fine at 100%). See the reporter's screenshot: the top strip and left column are solid light bands, the interior grid is correct.

## Root cause (gotcha #15)
The grid is drawn into an offscreen image sized to the canvas, composited with a scaling `_PUTIMAGE` at zoom ≥100%. The three document-creation paths had **drifted**: only Open (`DRW_load_binary`) recreated the grid image for the new canvas size. `DRW_new_canvas` / `DRW_create_canvas_at_size` kept the **stale** grid image left by the prior Crop — a small image the zoom `_PUTIMAGE` then stretched into thick edge bands.

## Fix
New shared `GRID_reinit_preserve` helper (recreate the grid image at the current `SCRN.canvasW/H`, preserving the user's current grid settings), called from **both** New paths after the new size is set. One helper → the paths can't drift apart again.

## Test
`QA/tests/grid-reinit-on-new-source-guards.sh` — source-guard that both New paths call the helper (guards the exact gotcha-#15 drift). Reproducing the crop→template→zoom flow offscreen is unreliable, so this guards the fix's marker; **please confirm the visual with your repro**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)