### PR TITLE
feat(settings): raise layer cap to 256 + "RESET ALL TO DEFAULT" button

### DIFF
--- a/CFG/CONFIG.BM
+++ b/CFG/CONFIG.BM
@@ -70,7 +70,7 @@ SUB CONFIG_set_defaults ()
     CFG.ANGLE_SNAP_DEGREES%             = 45                                              ' Angle snap increment for Ctrl+Shift line drawing (15/30/45/90)
     CFG.ANGLE_SNAP_PIXEL_ART%           = FALSE                                           ' Pixel art angle snap mode (integer slope ratios)
     ' Layer panel settings
-    CFG.NUM_LAYERS%         = 64                                                          ' Layer slots (1-MAX_LAYERS, currently 128)
+    CFG.NUM_LAYERS%         = 64                                                          ' Default layer cap (user-settable 1-MAX_LAYERS, currently 256)
     CFG.LAYER_PANEL_WIDTH%  = 150                                                         ' Layer panel width in pixels (min 40)
     CFG.LAYER_NAME_MAX_LEN% = 20                                                          ' Max layer name length (1-64)
     CFG.LAYER_GROUP_INDENT% = 0                                                           ' Per-level indent for nested groups (0=use theme default)

--- a/GUI/LAYERS.BI
+++ b/GUI/LAYERS.BI
@@ -136,11 +136,11 @@ TYPE LAYER_PANEL_OBJ
     iconBtnGroup     AS LONG         ' New group button icon
     ' Solo mode state (alt+click on eye icon)
     soloLayer        AS INTEGER      ' Layer index currently soloed (0 = none)
-    savedVisibility  AS STRING * 128 ' Saved visibility states before solo
+    savedVisibility  AS STRING * MAX_LAYERS ' Saved visibility states before solo (one char per layer slot)
     ' Visibility swipe state (click+drag on eye icons)
     visSwiping       AS INTEGER      ' TRUE while swiping visibility
     visSwipeAction   AS INTEGER      ' 1 = show, 0 = hide (action applied during swipe)
-    visSwipedLayers  AS STRING * 128 ' Track which layers were already swiped (CHR$(1) = swiped)
+    visSwipedLayers  AS STRING * MAX_LAYERS ' Track which layers were already swiped (CHR$(1) = swiped)
     ' Scrollbar drag state
     scrollDragging   AS INTEGER      ' TRUE while dragging the scroll thumb
     scrollDragOffset AS INTEGER      ' Y offset from thumb top where drag started

--- a/GUI/SETTINGS-TABS.BM
+++ b/GUI/SETTINGS-TABS.BM
@@ -95,9 +95,9 @@ SUB SETTINGS_render_general (ctx AS DIALOG_CTX, cx AS INTEGER, cy AS INTEGER, cw
     IF SW_checkbox_input%(ctx, cx%, y%, "Allow Multiple Instances", SETTINGS_CFG.ALLOW_MULTIPLE_INSTANCES) THEN SETTINGS.pendingChanges = TRUE
     SETTINGS_row_advance y%, SW_ROW_H
 
-    SW_TOOLTIP$ = "Maximum number of layer slots (1-64)"
+    SW_TOOLTIP$ = "Maximum number of layer slots (1-256)"
     SW_draw_spinner ctx, cx%, y%, cw%, SETTINGS_CFG.NUM_LAYERS, "Maximum Layers"
-    IF SW_spinner_input%(ctx, cx%, y%, cw%, SETTINGS_CFG.NUM_LAYERS, 1, 64) THEN SETTINGS.pendingChanges = TRUE
+    IF SW_spinner_input%(ctx, cx%, y%, cw%, SETTINGS_CFG.NUM_LAYERS, 1, MAX_LAYERS) THEN SETTINGS.pendingChanges = TRUE
     SETTINGS_row_advance y%, SW_ROW_H
 
     SW_TOOLTIP$ = "Initial brush radius in pixels"

--- a/GUI/SETTINGS.BM
+++ b/GUI/SETTINGS.BM
@@ -717,8 +717,13 @@ SUB SETTINGS_draw_button_bar ()
     DIM cancelX AS INTEGER : cancelX% = SETTINGS.ctx.w - SETTINGS_PADDING - SETTINGS_BTN_W
     DIM okX     AS INTEGER : okX% = cancelX% - gap% - SETTINGS_BTN_W
     DIM applyX  AS INTEGER : applyX% = okX% - gap% - SETTINGS_BTN_W
+    ' RESET ALL TO DEFAULT — wide button, bottom-LEFT. Auto-fit to its label (the
+    ' dialog font is active here, so _PRINTWIDTH is accurate).
+    DIM resetW  AS INTEGER : resetW% = _PRINTWIDTH("RESET ALL TO DEFAULT") + SETTINGS_PADDING * 2
+    DIM resetX  AS INTEGER : resetX% = SETTINGS_PADDING
 
     ' Draw buttons
+    DIALOG_draw_button SETTINGS.ctx, resetX%, bY%, resetW%, SETTINGS_BTN_H, "RESET ALL TO DEFAULT", THEME.DIALOG_toggle_bg~&, THEME.DIALOG_toggle_sel_bg~&, THEME.DIALOG_toggle_border~&
     DIALOG_draw_button SETTINGS.ctx, okX%, bY%, SETTINGS_BTN_W, SETTINGS_BTN_H, "OK", THEME.DIALOG_toggle_bg~&, THEME.DIALOG_toggle_sel_bg~&, THEME.DIALOG_toggle_border~&
     DIALOG_draw_button SETTINGS.ctx, cancelX%, bY%, SETTINGS_BTN_W, SETTINGS_BTN_H, "Cancel", THEME.DIALOG_toggle_bg~&, THEME.DIALOG_toggle_sel_bg~&, THEME.DIALOG_toggle_border~&
     DIALOG_draw_button SETTINGS.ctx, applyX%, bY%, SETTINGS_BTN_W, SETTINGS_BTN_H, "Apply", THEME.DIALOG_toggle_bg~&, THEME.DIALOG_toggle_sel_bg~&, THEME.DIALOG_toggle_border~&
@@ -741,6 +746,16 @@ SUB SETTINGS_draw_button_bar ()
             SETTINGS.reopenNeeded = TRUE
             SETTINGS.ctx.done     = TRUE
         END IF
+    END IF
+    IF DIALOG_hit%(SETTINGS.ctx, resetX%, bY%, resetW%, SETTINGS_BTN_H) THEN
+        ' Load factory defaults into the SHADOW config only — the live CFG stays
+        ' untouched until the user clicks Apply/OK (Cancel discards). CONFIG_set_defaults
+        ' writes into CFG (pure field assignments), so save/restore CFG around it.
+        DIM rstSavedCfg AS DRAW_CONFIG : rstSavedCfg = CFG
+        CONFIG_set_defaults
+        SETTINGS_CFG = CFG
+        CFG = rstSavedCfg
+        SETTINGS.pendingChanges = TRUE
     END IF
 END SUB
 

--- a/_COMMON.BI
+++ b/_COMMON.BI
@@ -34,8 +34,9 @@ CONST APP_VERSION$ = "2.1.1"
 ' Canvas pan step (pixels) for the Pan actions (470-473) — matches Shift+Wheel pan.
 CONST CANVAS_PAN_STEP = 40
 
-' Maximum number of layer slots (increased from 64 to support groups)
-CONST MAX_LAYERS = 128
+' Maximum number of layer slots — hard array bound. The user-facing cap is
+' CFG.NUM_LAYERS (Settings > General > Maximum Layers), which can be set up to this.
+CONST MAX_LAYERS = 256
 
 ' Title bar tracking (only update _TITLE when state changes)
 DIM SHARED AS INTEGER TITLE_PREV_DIRTY                     ' Previous frame's dirty state


### PR DESCRIPTION
## Summary

Two user-requested Settings improvements, in one branch since both touch the Settings/config chain.

### 1. Maximum layers 128 → 256
Bumping the constant alone would have left users stuck: the spinner was independently clamped to 64. Audited every link so the raised cap actually reaches the user:

| File | Change | Why |
|------|--------|-----|
| `_COMMON.BI` | `MAX_LAYERS` 128 → 256 | Hard array bound. Layer arrays are `(1 TO MAX_LAYERS)`, so they auto-scale. |
| `GUI/LAYERS.BI` | `savedVisibility` / `visSwipedLayers` `STRING * 128` → `STRING * MAX_LAYERS` | Solo-mode and visibility-swipe would otherwise silently track only the first 128 slots. |
| `GUI/SETTINGS-TABS.BM` | Maximum-Layers spinner clamp `1..64` → `1..MAX_LAYERS`; tooltip `(1-256)` | 64 was the *real* user-facing ceiling. |
| `CFG/CONFIG.BM` | comment only | `NUM_LAYERS` default stays 64; validation already clamps to `MAX_LAYERS`. |

### 2. "RESET ALL TO DEFAULT" button
Bottom-**left** of the Settings dialog button bar (Apply/OK/Cancel remain bottom-right). Auto-sized to its label via `_PRINTWIDTH` (the dialog font is active in the button-bar SUB, so the measurement is accurate).

Writes factory defaults into the **shadow** config only — snapshots `CFG`, runs the pure `CONFIG_set_defaults`, copies the result into `SETTINGS_CFG`, then restores `CFG`. So a reset stays **Cancel-undoable** and only lands on Apply/OK, exactly like every other control in the dialog.

## Testing
- Full build succeeds (exit 0).
- `STRING * MAX_LAYERS` verified to compile (standalone probe) before the full build.
- Visual confirmation of the button placement / spinner ceiling is worth a manual glance on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)