### PR TITLE
fix: CRT off by default + restore preview-window Alt-pick

### DIFF
--- a/CFG/CONFIG.BM
+++ b/CFG/CONFIG.BM
@@ -289,9 +289,10 @@ SUB CONFIG_set_defaults ()
     ' Anti-aliasing (experimental) — default OFF to preserve hard-edged pixel-art output.
     CFG.ANTIALIAS% = FALSE
     ' CRT overlay effect (presentation-only retro lens — on by default at low strength).
-    ' Subtle factory look: faint scanlines + phosphor mask + light vignette, no tint
-    ' (user picks their flavor). Low intensity keeps pixel art readable.
-    CFG.CRT_ENABLED%            = TRUE
+    ' CRT effect OFF by default (View → CRT Effect to enable). The sub-settings below
+    ' are the factory flavor applied when the user turns it on: faint scanlines +
+    ' phosphor mask + light vignette, no tint, low intensity to keep pixel art readable.
+    CFG.CRT_ENABLED%            = FALSE
     CFG.CRT_INTENSITY%          = 10
     CFG.CRT_SCANLINES%          = TRUE
     CFG.CRT_PHOSPHOR%           = TRUE

--- a/DRAW.cfg.default
+++ b/DRAW.cfg.default
@@ -466,7 +466,7 @@ ANTIALIAS=FALSE
 # CRT overlay effect (presentation-only retro lens — never written to canvas).
 # Always renders on the canvas work area only; UI chrome stays crisp.
 # Toggle with Ctrl+Alt+O or View > CRT Effect. Configure via View > CRT Effect Settings.
-CRT_ENABLED=TRUE
+CRT_ENABLED=FALSE
 # Global intensity 0-100% (scales scanlines + phosphor alphas)
 CRT_INTENSITY=10
 CRT_SCANLINES=TRUE

--- a/INPUT/MOUSE.BM
+++ b/INPUT/MOUSE.BM
@@ -5602,7 +5602,18 @@ FUNCTION MOUSE_process_frame% (rawX AS INTEGER, rawY AS INTEGER, wheel_delta AS 
     ' is excluded: there the loupe picker (MOUSE_handle_alt_picker) owns Alt and
     ' reads true layer colours. Ctrl is excluded so it can't collide with modifier
     ' combos; panning is excluded so a space/MMB pan is never hijacked.
-    IF MODIFIERS.alt% AND NOT MODIFIERS.ctrl% AND NOT SCRN.panning% THEN
+    ' The preview window owns Alt-pick over its own area (both Follow and Float
+    ' modes) via PREVIEW_pick_color_at, which samples the TRUE source image rather
+    ' than the composited screen pixel — so the screen eyedropper must defer to it,
+    ' exactly as the loupe picker does (see MOUSE_handle_alt_picker). Without this,
+    ' Alt+click in the floating-image preview is hijacked here and the preview's own
+    ' picker never runs — i.e. picking appears broken in float mode.
+    DIM edOverPreview%
+    edOverPreview% = FALSE
+    IF PREVIEW.visible% AND NOT PREVIEW.autoHidden% AND NOT BROWSER_owns_mouse%(rawX%, rawY%) THEN
+        edOverPreview% = PREVIEW_hit_window%(rawX%, rawY%)
+    END IF
+    IF MODIFIERS.alt% AND NOT MODIFIERS.ctrl% AND NOT SCRN.panning% AND NOT edOverPreview% THEN
         ' Over CHROME only (a registered panel, region id >= 2). The canvas floor
         ' is REGION_CANVAS (id 1) at ZORDER_CANVAS, so hit-test returns 1 over the
         ' drawing area and >= 2 over any chrome — use > REGION_CANVAS, NOT


### PR DESCRIPTION
Two small, independent fixes (separate commits).

## 1. CRT effect off by default
New installs start with the CRT overlay **off** (View → CRT Effect / Ctrl+Alt+O to enable). Flips the compiled default (`CONFIG_set_defaults`) and shipped `DRAW.cfg.default`. Existing saved configs are untouched — only the factory default changes.

## 2. Restore Alt-pick in the preview window (both modes)
The "Alt+click over UI chrome = screen eyedropper" feature fires *before* the preview's own click handler and exits the frame, so Alt+click over the preview window was hijacked — sampling the composited on-screen pixel instead of letting the preview sample the **true source image**. In floating-image mode this looked like "can't pick colors."

Fix: exclude the preview window from the screen eyedropper (the same carve-out the loupe picker already has at `MOUSE_handle_alt_picker`), so the click falls through to `PREVIEW_pick_color_at`, which samples correctly in both Follow and Float modes. The eyedropper still works over all other chrome.

## Testing
- Combined build succeeds (exit 0).
- Resize-feel change is a separate PR (#113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)