### PR TITLE
fix(mouse): [macOS] recover drag tracking during the post-launch activation gap

### DIFF
--- a/DRAW.BAS
+++ b/DRAW.BAS
@@ -33,6 +33,19 @@ screen_shown = 0
 '$INCLUDE:'./_ALL.BI'
 $RESIZE:ON
 
+' [macOS] Global cursor fallback (INPUT/cursorpos.h). macOS drops mouseDragged
+' events to a window until the app finishes activating after launch, so a drag
+' begun in that gap freezes _MOUSEX (every QB64-PE GLFW app hits this — it is a
+' platform bug, not DRAW's). CGEventGetLocation still reports the true cursor
+' regardless of activation, so MOUSE_drain_update_state falls back to it when the
+' _MOUSEINPUT motion stream stalls mid-drag. See PLANS / the drag-collapse notes.
+$IF MAC THEN
+    DECLARE LIBRARY "INPUT/cursorpos"
+        SUB DRAW_global_cursor (BYVAL px AS _OFFSET, BYVAL py AS _OFFSET)
+        FUNCTION DRAW_backing_scale#
+    END DECLARE
+$END IF
+
 ' SCREEN_init (from SCREEN.BI, above) has created the window by now, so from
 ' this point a human can actually see and dismiss things. Deliberately keyed on
 ' "is a window up?" rather than a devmode/CLI-flag check — a curated list of

--- a/INPUT/INPUT.BI
+++ b/INPUT/INPUT.BI
@@ -411,6 +411,23 @@ DIM SHARED INPUT_DISPATCH_DEPTH AS INTEGER
 DIM SHARED DEV_MODE        AS INTEGER
 DIM SHARED INPUTS_LOG_PATH AS STRING
 
+' Count of _MOUSEINPUT events consumed by the main drain this frame. The macOS
+' global-cursor fallback (MOUSE_drain_update_state) uses it to tell a fresh
+' _MOUSEX (event arrived) from a stalled one (mouseDragged withheld during the
+' post-launch activation gap).
+DIM SHARED MOUSE_FRAME_EVTS AS INTEGER
+
+' [macOS] Global-cursor fallback calibration (see DRAW_global_cursor). Maps the
+' OS global cursor (physical pixels) onto DRAW's viewport coords. SCALE = global
+' units per viewport pixel = display backing scale / SCRN.displayScale (the backing
+' scale comes from DRAW_backing_scale). ORIG is captured whenever a real
+' _MOUSEINPUT event proves _MOUSEX is fresh, so the gap reconstruction lands under
+' the pointer regardless of Retina/UI scale.
+DIM SHARED MOUSE_MAC_CALIBRATED AS INTEGER
+DIM SHARED MOUSE_MAC_SCALE      AS SINGLE
+DIM SHARED MOUSE_MAC_ORIGX      AS SINGLE
+DIM SHARED MOUSE_MAC_ORIGY      AS SINGLE
+
 
 ' DECLARE SUB/FUNCTION blocks removed — QB64-PE auto-discovers SUBs and
 ' FUNCTIONs from the include chain. Only DECLARE LIBRARY still needs an

--- a/INPUT/MOUSE.BM
+++ b/INPUT/MOUSE.BM
@@ -61,6 +61,7 @@ SUB MOUSE_drain_update_state (rawX AS INTEGER, rawY AS INTEGER, wheel_delta AS I
     ' then SGN to a plain -1/0/+1 trigger (Rick's choice, not magnitude-aware).
     DIM tilt_accum AS INTEGER : tilt_accum% = 0
     MOUSE_TILT% = 0
+    MOUSE_FRAME_EVTS% = 0 ' events consumed by this frame's drain (see INPUT.BI)
 
     $IF MAC THEN
         ' macOS: capture button states DURING the drain so a trackpad tap-to-click
@@ -90,6 +91,7 @@ SUB MOUSE_drain_update_state (rawX AS INTEGER, rawY AS INTEGER, wheel_delta AS I
         DIM mac_b1 AS INTEGER, mac_b2 AS INTEGER, mac_b3 AS INTEGER
         mac_b1% = FALSE: mac_b2% = FALSE: mac_b3% = FALSE
         DO WHILE _MOUSEINPUT
+            MOUSE_FRAME_EVTS% = MOUSE_FRAME_EVTS% + 1
             wheel_delta% = wheel_delta% + _MOUSEWHEEL
             IF MOUSE_TILT_AXIS% > 0 THEN tilt_accum% = tilt_accum% + _MOUSEWHEEL(MOUSE_TILT_AXIS%)
             ' Capture any button presses during the drain
@@ -99,6 +101,7 @@ SUB MOUSE_drain_update_state (rawX AS INTEGER, rawY AS INTEGER, wheel_delta AS I
         LOOP
     $ELSE
         DO WHILE _MOUSEINPUT
+            MOUSE_FRAME_EVTS% = MOUSE_FRAME_EVTS% + 1
             wheel_delta% = wheel_delta% + _MOUSEWHEEL
             IF MOUSE_TILT_AXIS% > 0 THEN tilt_accum% = tilt_accum% + _MOUSEWHEEL(MOUSE_TILT_AXIS%)
         LOOP
@@ -106,9 +109,53 @@ SUB MOUSE_drain_update_state (rawX AS INTEGER, rawY AS INTEGER, wheel_delta AS I
     MOUSE_TILT% = SGN(tilt_accum%)
     IF MOUSE_TILT% <> 0 AND CFG.DEVELOPER_MODE% THEN _LOGINFO "mouse-tilt: dir=" + _TRIM$(STR$(MOUSE_TILT%)) + " (axis=" + _TRIM$(STR$(MOUSE_TILT_AXIS%)) + ")"
 
-    ' Get window coordinates and scale down by display scale to viewport coords
-    rawX% = _MOUSEX \ SCRN.displayScale%
-    rawY% = _MOUSEY \ SCRN.displayScale%
+    ' Get window coordinates and scale down by display scale to viewport coords.
+    DIM evRawX AS INTEGER, evRawY AS INTEGER
+    evRawX% = _MOUSEX \ SCRN.displayScale%
+    evRawY% = _MOUSEY \ SCRN.displayScale%
+    $IF MAC THEN
+        ' [macOS] mouseDragged is withheld until the app finishes activating after
+        ' launch, so a drag begun in that gap freezes _MOUSEX (every QB64-PE GLFW
+        ' app hits this — a platform bug, not DRAW's). Whenever a real _MOUSEINPUT
+        ' event arrives, _MOUSEX is fresh: capture the window origin so the OS global
+        ' cursor (CGEventGetLocation, which tracks regardless of activation) maps onto
+        ' window coords. When the motion stream stalls MID-DRAG (no event but a button
+        ' is held), derive the position from the global cursor instead of the frozen
+        ' _MOUSEX, so the stroke follows the pointer.
+        DIM gcx AS DOUBLE, gcy AS DOUBLE
+        DRAW_global_cursor _OFFSET(gcx), _OFFSET(gcy)
+        DIM heldNow AS INTEGER
+        heldNow% = (_MOUSEBUTTON(1) OR _MOUSEBUTTON(2) OR _MOUSEBUTTON(3))
+        ' CGEventGetLocation reports screen POINTS; _MOUSEX reports backing pixels,
+        ' and evRawX = _MOUSEX \ displayScale. So global points per viewport pixel is
+        ' SCRN.displayScale / backingScale (e.g. 4/2 = 2 on this Retina setup).
+        ' Whenever a real _MOUSEINPUT event arrives, _MOUSEX is fresh: capture the
+        ' viewport origin in global space so the gap reconstruction lands exactly
+        ' under the pointer. When motion stalls mid-drag (button held, no event),
+        ' derive the viewport coord from the live global cursor.
+        IF MOUSE_MAC_SCALE! <= 0 THEN
+            DIM bScale AS DOUBLE : bScale# = DRAW_backing_scale#
+            IF bScale# <= 0 THEN bScale# = 1
+            MOUSE_MAC_SCALE! = SCRN.displayScale% / bScale#
+            IF MOUSE_MAC_SCALE! <= 0 THEN MOUSE_MAC_SCALE! = 1
+        END IF
+        IF MOUSE_FRAME_EVTS% > 0 OR NOT MOUSE_MAC_CALIBRATED% THEN
+            MOUSE_MAC_ORIGX!      = gcx - evRawX% * MOUSE_MAC_SCALE!
+            MOUSE_MAC_ORIGY!      = gcy - evRawY% * MOUSE_MAC_SCALE!
+            MOUSE_MAC_CALIBRATED% = TRUE
+            rawX% = evRawX%
+            rawY% = evRawY%
+        ELSEIF heldNow% THEN
+            rawX% = INT((gcx - MOUSE_MAC_ORIGX!) / MOUSE_MAC_SCALE!)
+            rawY% = INT((gcy - MOUSE_MAC_ORIGY!) / MOUSE_MAC_SCALE!)
+        ELSE
+            rawX% = evRawX%
+            rawY% = evRawY%
+        END IF
+    $ELSE
+        rawX% = evRawX%
+        rawY% = evRawY%
+    $END IF
 
     ' Store raw screen coordinates for GUI hover detection
     MOUSE.RAW_X% = rawX%
@@ -2837,6 +2884,12 @@ SUB MOUSE_tool_brush ()
             END IF
         END IF
         STROKE_begin
+        ' Anchor the stroke at the press point. PAINT_on interpolates OLD->current,
+        ' so a stale OLD (e.g. MOUSE_init's 1,1 or a post-dialog 0,0) streaks a line
+        ' from the canvas corner into the first frame of the very first stroke after
+        ' launch. MOUSE_tool_dot already primes this; do the same here.
+        MOUSE.OLD_X% = MOUSE.X%
+        MOUSE.OLD_Y% = MOUSE.Y%
         ' Initialize gradient context at stroke start for running bounds
         GRAD_CTX_set MOUSE.X%, MOUSE.Y%, MOUSE.X%, MOUSE.Y%
     END IF

--- a/INPUT/cursorpos.h
+++ b/INPUT/cursorpos.h
@@ -1,0 +1,26 @@
+// [macOS] Helpers for the drag-collapse fallback (see MOUSE_drain_update_state).
+// macOS withholds mouseDragged from a freshly-launched window until the app
+// finishes activating, freezing _MOUSEX mid-drag. CGEventGetLocation still tracks
+// the true cursor, and DRAW_backing_scale gives the physical/points ratio so the
+// global coords can be mapped onto DRAW's viewport at the right scale.
+#include <ApplicationServices/ApplicationServices.h>
+#include <stdint.h>
+
+void DRAW_global_cursor(uintptr_t px, uintptr_t py){
+    CGEventRef e = CGEventCreate(0);
+    CGPoint p = CGEventGetLocation(e);
+    if (e) CFRelease(e);
+    *(double*)px = p.x;
+    *(double*)py = p.y;
+}
+
+// Backing scale of the main display (2.0 on Retina, 1.0 otherwise).
+double DRAW_backing_scale(void){
+    CGDirectDisplayID d = CGMainDisplayID();
+    CGDisplayModeRef m = CGDisplayCopyDisplayMode(d);
+    if (!m) return 1.0;
+    double px = (double)CGDisplayModeGetPixelWidth(m);
+    double pt = (double)CGDisplayModeGetWidth(m);
+    CGDisplayModeRelease(m);
+    return (pt > 0.0) ? (px / pt) : 1.0;
+}


### PR DESCRIPTION
## What

Fixes the macOS bug where the first brush/drag stroke after launch collapses to a
straight line (\"dots/lines until you switch tools and back\").

**Root cause (a QB64-PE/GLFW platform bug, not DRAW):** for ~1–2 s after launch,
until macOS finishes *activating* the app, Cocoa withholds `mouseDragged` from the
window. `_MOUSEINPUT` delivers no motion while a button is held, `_MOUSEX` freezes,
and every drag tool collapses — until any interaction (a tool switch) completes
activation. Reproduced in bare `SCREEN`+`_MOUSEINPUT` probes with zero DRAW code.
Reported upstream: QB64-Phoenix-Edition/QB64pe#774.

## Fix

- When the `_MOUSEINPUT` motion stream stalls mid-drag, source the cursor from
  `CGEventGetLocation()` and map global points → viewport pixels via
  `SCRN.displayScale / backing-scale`, self-calibrating origin from the last real
  event. Fully `$IF MAC`-guarded — **Linux/Windows unchanged**.
- New tiny CoreGraphics helper `INPUT/cursorpos.h` (links against the
  ApplicationServices the macOS build already pulls in).
- Prime `MOUSE.OLD_X/Y` on brush press (as `MOUSE_tool_dot` does) → no more
  first-stroke corner streak.

## Verified

- macOS: brush tracks accurately during the activation gap (a 350×210-pt drag
  moves the brush exactly 175×105 canvas px, under the cursor). Confirmed by hand + automation.
- Cross-platform: mac-only code is behind `$IF MAC`; `$ELSE` path is the original
  `_MOUSEX \ displayScale`. CI here validates Linux/macOS/Windows builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJx94uMAP32qvGt5XXYmP4