### PR TITLE
fix: small-display scaling, palette-dropdown occlusion, and tooltip wrapping

### DIFF
--- a/GUI/ADV-COLOR-PICKER.BM
+++ b/GUI/ADV-COLOR-PICKER.BM
@@ -331,6 +331,7 @@ SUB ADVCP_render ()
     IF LAYER_PANEL.ctxMenuOpen% THEN EXIT SUB
     IF DRAWER.contextMenuOpen% THEN EXIT SUB
     IF CMD_PALETTE.visible THEN EXIT SUB
+    IF PALETTE_MENU_VISIBLE% THEN EXIT SUB   ' palette-name dropdown (bottom-right) floats above
 
     ' Blit to screen 0 at integer toolbar scale.
     DIM ts AS INTEGER, ds AS INTEGER

--- a/GUI/COLOR-MIXER.BM
+++ b/GUI/COLOR-MIXER.BM
@@ -413,6 +413,7 @@ SUB COLORMIXER_render ()
     IF LAYER_PANEL.ctxMenuOpen%    THEN EXIT SUB
     IF DRAWER.contextMenuOpen%     THEN EXIT SUB
     IF CMD_PALETTE.visible         THEN EXIT SUB
+    IF PALETTE_MENU_VISIBLE%       THEN EXIT SUB   ' palette-name dropdown (bottom-right) floats above
 
     ' Blit dialog to screen 0 using an integer toolbarScale upscale so that
     ' fonts are never stretched to a non-integer ratio.

--- a/GUI/SETTINGS-WIDGETS.BM
+++ b/GUI/SETTINGS-WIDGETS.BM
@@ -1215,27 +1215,62 @@ END FUNCTION
 SUB SW_draw_tooltip (ctx AS DIALOG_CTX)
     IF NOT SW_TIP.active THEN EXIT SUB
 
-    DIM tipText AS STRING                           : tipText$ = _TRIM$(SW_TIP.text)
+    DIM tipText AS STRING : tipText$ = _TRIM$(SW_TIP.text)
     IF LEN(tipText$) = 0 THEN SW_TIP.active = FALSE : EXIT SUB
 
     DIM fontH AS INTEGER : fontH% = DIALOG_font_height%(ctx)
-    DIM tw    AS INTEGER : tw% = _PRINTWIDTH(tipText$) + 8
-    DIM th    AS INTEGER : th% = fontH% + 6
-    DIM tx    AS INTEGER : tx% = SW_TIP.x + 12
-    DIM ty    AS INTEGER : ty% = SW_TIP.y - th% - 4
 
-    ' Keep tooltip on screen
+    ' Wrap to the CONTENT AREA, not the screen. SW_draw_tooltip renders onto the
+    ' dialog's clip buffer (the current _DEST), so _WIDTH/_HEIGHT are the parent
+    ' container's bounds. The old single-line tooltip drew past the right edge and
+    ' was clipped off; now it wraps to fit, using the shared TOOLTIP_wrap_line.
     DIM destW AS INTEGER, destH AS INTEGER
     destW% = _WIDTH : destH% = _HEIGHT
+    DIM budget AS INTEGER, capPx AS INTEGER, avgCW AS INTEGER
+    avgCW% = _PRINTWIDTH("abcdefghijklmnopqrstuvwxyz") \ 26
+    IF avgCW% < 1 THEN avgCW% = 1
+    capPx% = avgCW% * TOOLTIP_MAX_CONTENT_CHARS
+    budget% = destW% - 16                 ' box padding (8) + a little breathing room
+    IF budget% > capPx% THEN budget% = capPx%
+    IF budget% < 40 THEN budget% = 40
+
+    DIM tRows(1 TO 40) AS STRING, tBold(1 TO 40) AS INTEGER
+    DIM rc AS INTEGER : rc% = 0
+    TOOLTIP_wrap_line tipText$, 0, budget%, tRows(), tBold(), rc%
+    IF rc% = 0 THEN SW_TIP.active = FALSE : EXIT SUB
+
+    ' Widest wrapped row → box width
+    DIM maxW AS INTEGER, i AS INTEGER, ww AS INTEGER
+    maxW% = 0
+    FOR i% = 1 TO rc%
+        ww% = _PRINTWIDTH(tRows(i%))
+        IF ww% > maxW% THEN maxW% = ww%
+    NEXT i%
+
+    DIM tw AS INTEGER : tw% = maxW% + 8
+    DIM th AS INTEGER : th% = fontH% * rc% + 6
+    IF rc% > 1 THEN th% = th% + (rc% - 1)          ' 1px inter-line gap
+    DIM tx AS INTEGER : tx% = SW_TIP.x + 12
+    DIM ty AS INTEGER : ty% = SW_TIP.y - th% - 4
+
+    ' Keep the (now multi-line) box inside the content area
     IF tx% + tw% > destW% - 2 THEN tx% = destW% - tw% - 2
     IF tx% < 2 THEN tx% = 2
-    IF ty% < 2 THEN ty% = SW_TIP.y + 18
+    IF ty% < 2 THEN ty% = SW_TIP.y + 18            ' flip below the widget if no room above
+    IF ty% + th% > destH% - 2 THEN ty% = destH% - th% - 2
+    IF ty% < 2 THEN ty% = 2
 
-    ' Draw tooltip background with border
+    ' Background + border
     LINE (tx% - 1, ty% - 1)-(tx% + tw%, ty% + th%), _RGB32(20, 20, 28), BF
     LINE (tx% - 1, ty% - 1)-(tx% + tw%, ty% + th%), _RGB32(90, 90, 110), B
+
+    ' Text rows
     COLOR _RGB32(210, 210, 220)
-    _UPRINTSTRING (tx% + 4, ty% + 3), tipText$
+    DIM lineY AS INTEGER : lineY% = ty% + 3
+    FOR i% = 1 TO rc%
+        _UPRINTSTRING (tx% + 4, lineY%), tRows(i%)
+        lineY% = lineY% + fontH% + 1
+    NEXT i%
 
     SW_TIP.active = FALSE
 END SUB

--- a/GUI/TOOLTIP.BI
+++ b/GUI/TOOLTIP.BI
@@ -22,6 +22,14 @@ CONST TOOLTIP_SRC_SUBTOOL_FLYOUT = 10
 CONST TOOLTIP_SRC_LAYER_NO_PAINT = 11 ' Pencil-with-slash badge on a group header row
 CONST TOOLTIP_SRC_ACP_HISTORY    = 12 ' Advanced Color Picker — history strip
 
+' Readability cap on tooltip line length, in CHARACTERS (converted to pixels through
+' the current font, so it scales correctly whether the tooltip uses the fixed 8px
+' floating font or the UI-scaled dialog font). Renderers also clamp to their
+' container width, so a tooltip never overflows; this cap just stops lines from
+' growing uncomfortably long on wide containers. Most existing one-line tooltips are
+' shorter than this, so they are unaffected. Tunable.
+CONST TOOLTIP_MAX_CONTENT_CHARS  = 90
+
 TYPE TOOLTIP_OBJ
     ACTIVE        AS INTEGER ' TRUE when a tooltip is currently visible
     HOVER_BTN_IDX AS INTEGER ' Index into currently hovered element (-1 = none)

--- a/GUI/TOOLTIP.BM
+++ b/GUI/TOOLTIP.BM
@@ -406,6 +406,80 @@ END SUB
 ' Called from SCREEN_render after final overlay popups.
 ' @param target LONG Destination image handle to draw the tooltip onto
 '
+''
+' TOOLTIP_wrap_line — greedy word-wrap `text$` to at most `maxPixW%` pixels per
+' visual line using the CURRENT _FONT, appending each visual line to outRows() and
+' its bold flag to outBold() (fixed-size, 1-based arrays) while advancing rowCount%.
+'
+' Shared by every tooltip renderer -- the floating TOOLTIP_render and the Settings
+' dialog's SW_draw_tooltip -- so a tooltip wraps to fit WHATEVER container the caller
+' passes as maxPixW% (the window for floating tooltips, the dialog content area for
+' dialog tooltips) instead of assuming the screen and spilling off / clipping.
+'
+' Breaks on spaces; a single word wider than maxPixW% is hard-broken by character so
+' nothing ever exceeds the budget. Stops when outRows() is full. The caller sets the
+' font first (measurement uses it) and passes its running row total as rowCount%, so
+' several logical lines can be wrapped into one shared array.
+' @param text$    STRING  One logical line of tooltip text
+' @param isBold%  INTEGER Bold flag stamped on every visual row this line produces
+' @param maxPixW% INTEGER Max content width in pixels (the caller's container)
+' @param outRows() STRING  (out) visual rows appended here
+' @param outBold() INTEGER (out) per-row bold flag
+' @param rowCount% INTEGER (in/out) running row count
+'
+SUB TOOLTIP_wrap_line (text$, isBold%, maxPixW%, outRows() AS STRING, outBold() AS INTEGER, rowCount%)
+    IF LEN(text$) = 0 THEN EXIT SUB
+    DIM maxRows AS INTEGER : maxRows% = UBOUND(outRows)
+    IF rowCount% >= maxRows% THEN EXIT SUB
+    DIM budget AS INTEGER : budget% = maxPixW%
+    IF budget% < 8 THEN budget% = 8
+    DIM s AS STRING, curLine AS STRING, wrd AS STRING, testLine AS STRING
+    DIM sp AS INTEGER, cut AS INTEGER
+    s$ = text$ : curLine$ = ""
+    DO WHILE LEN(s$) > 0 _ANDALSO rowCount% < maxRows%
+        sp% = INSTR(s$, " ")
+        IF sp% = 0 THEN
+            wrd$ = s$ : s$ = ""
+        ELSE
+            wrd$ = LEFT$(s$, sp% - 1) : s$ = MID$(s$, sp% + 1)
+        END IF
+        IF LEN(wrd$) > 0 THEN
+            ' Hard-break a word too wide to ever fit on one line.
+            DO WHILE rowCount% < maxRows% _ANDALSO LEN(wrd$) > 1 _ANDALSO _PRINTWIDTH(wrd$) > budget%
+                cut% = LEN(wrd$) - 1
+                DO WHILE cut% > 1 _ANDALSO _PRINTWIDTH(LEFT$(wrd$, cut%)) > budget%
+                    cut% = cut% - 1
+                LOOP
+                IF LEN(curLine$) > 0 THEN
+                    rowCount% = rowCount% + 1 : outRows(rowCount%) = curLine$ : outBold(rowCount%) = isBold%
+                    curLine$ = ""
+                    IF rowCount% >= maxRows% THEN EXIT SUB
+                END IF
+                rowCount% = rowCount% + 1 : outRows(rowCount%) = LEFT$(wrd$, cut%) : outBold(rowCount%) = isBold%
+                wrd$ = MID$(wrd$, cut% + 1)
+            LOOP
+            IF rowCount% >= maxRows% THEN EXIT DO
+            IF LEN(curLine$) = 0 THEN
+                testLine$ = wrd$
+            ELSE
+                testLine$ = curLine$ + " " + wrd$
+            END IF
+            IF _PRINTWIDTH(testLine$) <= budget% THEN
+                curLine$ = testLine$
+            ELSE
+                IF LEN(curLine$) > 0 THEN
+                    rowCount% = rowCount% + 1 : outRows(rowCount%) = curLine$ : outBold(rowCount%) = isBold%
+                END IF
+                curLine$ = wrd$
+            END IF
+        END IF
+    LOOP
+    IF LEN(curLine$) > 0 _ANDALSO rowCount% < maxRows% THEN
+        rowCount% = rowCount% + 1 : outRows(rowCount%) = curLine$ : outBold(rowCount%) = isBold%
+    END IF
+END SUB
+
+
 SUB TOOLTIP_render (target&)
     ' Clear render bounds — prevents stale reblit if we exit early this frame.
     TOOLTIP.RENDER_W% = 0
@@ -531,36 +605,48 @@ SUB TOOLTIP_render (target&)
     oldFont& = _FONT
     IF TOOLTIP.FONT_HANDLE& > 0 THEN _FONT TOOLTIP.FONT_HANDLE&
 
-    ' Measure text widths
-    DIM w1    AS INTEGER, w2 AS INTEGER, w3 AS INTEGER, maxW AS INTEGER
     DIM fontH AS INTEGER
     fontH% = _UFONTHEIGHT
-    w1%    = _PRINTWIDTH(line1$)
-    IF LEN(line2$) > 0 THEN
-        w2% = _PRINTWIDTH(line2$)
-    ELSE
-        w2% = 0
-    END IF
-    IF LEN(line3$) > 0 THEN
-        w3% = _PRINTWIDTH(line3$)
-    ELSE
-        w3% = 0
-    END IF
-    maxW% = w1%
-    IF w2% > maxW% THEN maxW% = w2%
-    IF w3% > maxW% THEN maxW% = w3%
 
-    ' Calculate tooltip dimensions
     DIM pad AS INTEGER, bw AS INTEGER
     pad% = THEME.TOOLTIP_PADDING%
     IF pad% < 1 THEN pad% = 3
     bw% = THEME.TOOLTIP_BORDER_WIDTH%
     IF bw% < 0 THEN bw% = 1
 
+    ' Word-wrap each logical line to fit this tooltip's container (the window that
+    ' `target&` renders to), capped for readability. Long lines used to render past
+    ' the right edge; now they wrap. Line 1 stays bold, lines 2-3 normal.
+    DIM wrapW AS INTEGER, capPx AS INTEGER, avgCW AS INTEGER
+    avgCW% = _PRINTWIDTH("abcdefghijklmnopqrstuvwxyz") \ 26
+    IF avgCW% < 1 THEN avgCW% = 1
+    capPx% = avgCW% * TOOLTIP_MAX_CONTENT_CHARS
+    wrapW% = _WIDTH(target&) - 2 * (pad% + bw%) - 8
+    IF wrapW% > capPx% THEN wrapW% = capPx%
+    IF wrapW% < 40 THEN wrapW% = 40
+
+    DIM ttRows(1 TO 40) AS STRING, ttBold(1 TO 40) AS INTEGER
+    DIM rowCount AS INTEGER
+    rowCount% = 0
+    TOOLTIP_wrap_line line1$, -1, wrapW%, ttRows(), ttBold(), rowCount%
+    TOOLTIP_wrap_line line2$, 0, wrapW%, ttRows(), ttBold(), rowCount%
+    TOOLTIP_wrap_line line3$, 0, wrapW%, ttRows(), ttBold(), rowCount%
+    IF rowCount% = 0 THEN
+        IF oldFont& > 0 THEN _FONT oldFont&
+        _DEST oldDest&
+        EXIT SUB
+    END IF
+
+    ' Widest wrapped row → content width
+    DIM maxW AS INTEGER, mi AS INTEGER, rww AS INTEGER
+    maxW% = 0
+    FOR mi% = 1 TO rowCount%
+        rww% = _PRINTWIDTH(ttRows(mi%))
+        IF rww% > maxW% THEN maxW% = rww%
+    NEXT mi%
+
     DIM numLines AS INTEGER
-    numLines% = 1
-    IF LEN(line2$) > 0 THEN numLines% = numLines% + 1
-    IF LEN(line3$) > 0 THEN numLines% = numLines% + 1
+    numLines% = rowCount%
 
     DIM ttW AS INTEGER, ttH AS INTEGER
     ttW% = maxW% + pad% * 2 + bw% * 2
@@ -632,26 +718,16 @@ SUB TOOLTIP_render (target&)
     ' Draw text with transparent background (keep tooltip BG visible behind glyphs)
     _PRINTMODE _KEEPBACKGROUND
 
-    ' Draw line 1 (bold/hotkey color)
-    DIM textX AS INTEGER, textY AS INTEGER
+    ' Draw each wrapped row with its own colour (wrapped line-1 rows stay bold,
+    ' line-2/3 rows normal).
+    DIM textX AS INTEGER, textY AS INTEGER, dri AS INTEGER
     textX% = ttX% + pad% + bw%
     textY% = ttY% + pad% + bw%
-    COLOR boldColor~&
-    _UPRINTSTRING (textX%, textY%), line1$
-
-    ' Draw line 2 (normal color)
-    IF LEN(line2$) > 0 THEN
+    FOR dri% = 1 TO rowCount%
+        IF ttBold(dri%) THEN COLOR boldColor~& ELSE COLOR fgColor~&
+        _UPRINTSTRING (textX%, textY%), ttRows(dri%)
         textY% = textY% + fontH% + 1
-        COLOR fgColor~&
-        _UPRINTSTRING (textX%, textY%), line2$
-    END IF
-
-    ' Draw line 3 (normal color)
-    IF LEN(line3$) > 0 THEN
-        textY% = textY% + fontH% + 1
-        COLOR fgColor~&
-        _UPRINTSTRING (textX%, textY%), line3$
-    END IF
+    NEXT dri%
 
     ' Mark tooltip as rendered — allows idle detection to stop burning CPU
     TOOLTIP.NEEDS_REDRAW% = FALSE

--- a/INPUT/INPUT.BI
+++ b/INPUT/INPUT.BI
@@ -423,10 +423,15 @@ DIM SHARED MOUSE_FRAME_EVTS AS INTEGER
 ' scale comes from DRAW_backing_scale). ORIG is captured whenever a real
 ' _MOUSEINPUT event proves _MOUSEX is fresh, so the gap reconstruction lands under
 ' the pointer regardless of Retina/UI scale.
-DIM SHARED MOUSE_MAC_CALIBRATED AS INTEGER
-DIM SHARED MOUSE_MAC_SCALE      AS SINGLE
-DIM SHARED MOUSE_MAC_ORIGX      AS SINGLE
-DIM SHARED MOUSE_MAC_ORIGY      AS SINGLE
+' These are read/written only inside $IF MAC blocks (see DRAW_global_cursor use in
+' INPUT/MOUSE.BM), so declare them only on macOS — otherwise Windows/Linux builds warn
+' "Unused variable" for four globals the non-mac code never touches.
+$IF MAC THEN
+    DIM SHARED MOUSE_MAC_CALIBRATED AS INTEGER
+    DIM SHARED MOUSE_MAC_SCALE      AS SINGLE
+    DIM SHARED MOUSE_MAC_ORIGX      AS SINGLE
+    DIM SHARED MOUSE_MAC_ORIGY      AS SINGLE
+$END IF
 
 
 ' DECLARE SUB/FUNCTION blocks removed — QB64-PE auto-discovers SUBs and

--- a/OUTPUT/SCREEN.BI
+++ b/OUTPUT/SCREEN.BI
@@ -140,6 +140,14 @@ GRAYSCALE_PREVIEW_ACTIVE% = FALSE
 ' z-index overlaps of chrome elements right at the minimum window size.
 CONST WIN_MIN_PADDING = 100
 
+' Min-canvas floor (viewport px) used ONLY for an EXPLICIT user scale request (Settings
+' UI Scale, scale hotkeys). Auto-detect keeps the comfortable ~320px canvas in
+' SCREEN_chrome_min_w&/h&; when the user deliberately picks a larger scale on a small
+' desktop we honour it with a smaller canvas rather than silently reverting the scale
+' to 1x. The docked-chrome floor (toolbox/layers/edit-bar width; toolbar-column height)
+' and the configured WIN_MIN_* still apply, so the chrome always physically renders.
+CONST CHROME_MIN_CANVAS_RELAXED = 64
+
 ' Programmatic resize echo suppression.
 ' Before a programmatic SCREEN _NEWIMAGE we record the target size in
 ' SCREEN_DEFERRED_W/H and set SCREEN_DEFERRED_RESIZE to a small frame budget. The

--- a/OUTPUT/SCREEN.BM
+++ b/OUTPUT/SCREEN.BM
@@ -198,35 +198,28 @@ END SUB
 
 
 ''
-' Estimates the highest TOOLBAR_SCALE that fits in the given viewport,
-' using PROPORTIONAL thresholds relative to the unscaled 12px menu bar.
+' Returns the chrome (toolbar-column) scale that will ACTUALLY render at a given
+' display scale, resolved the SAME way as SCALE_resolve_widgets: the master display
+' scale times SCALE_RATIO_TOOLBAR (default 0.5), or the explicit TOOLBAR_SCALE
+' override, clamped 1-4.
 '
-' The menu bar is always 12px (8px font + 4px padding).
-' TB=2 (22px buttons) gives a 1.8:1 ratio vs menu — good.
-' TB=3 (33px) gives 2.75:1 — only acceptable with very large viewports
-'   where the menu text looks tiny and bigger buttons help.
-' TB=4 (44px) gives 3.67:1 — only for huge viewports (scale=1 or 2 on 4K).
+' Fit/safety checks MUST use this, never a viewport-size guess. Since the unified
+' UI_SCALE collapse, the docked toolbar/organizer/drawer column is sized from this
+' ratio — chrome is ~half the display scale (TB=1 at scale 2, TB=2 at scale 3-4).
+' The old viewport-based estimate disagreed: it reported TB=2 for a mid-size
+' viewport that in reality renders TB=1, over-stating the chrome height by ~2x and
+' needlessly knocking the display scale down on short screens. That dropped 1366x768
+' (and every desktop shorter than ~900px) from 2x to 1x — tiny chrome, buried canvas.
+' Measuring against the ratio that actually renders keeps the fit math and the render
+' math in sync, so display scale only steps down when even the reduced chrome won't fit.
+' @param ds INTEGER Candidate display (master) scale
+' @return INTEGER - Chrome/toolbar scale that will render (1-4)
 '
-' These thresholds are intentionally high: TB=2 is the typical auto-detect
-' result. TB=3/4 require viewports so large that the 12px menu bar itself
-' appears proportionally small.
-' @param vpW LONG Viewport width in pixels
-' @param vpH LONG Viewport height in pixels
-' @return INTEGER - Recommended toolbar scale (1-4)
-'
-FUNCTION SCREEN_estimate_toolbar_scale% (vpW AS LONG, vpH AS LONG)
-    ' TB=4 only when viewport is enormous (e.g., 4K at 1x or 2x scale)
-    IF vpW& >= 1200 AND vpH& >= 900 THEN
-        SCREEN_estimate_toolbar_scale% = 4
-    ' TB=3 for large viewports (e.g., 1440p+ at 2x)
-    ELSEIF vpW& >= 900 AND vpH& >= 700 THEN
-        SCREEN_estimate_toolbar_scale% = 3
-    ' TB=2 is the standard for most auto-detect scenarios
-    ELSEIF vpW& >= 440 AND vpH& >= 300 THEN
-        SCREEN_estimate_toolbar_scale% = 2
-    ELSE
-        SCREEN_estimate_toolbar_scale% = 1
-    END IF
+FUNCTION SCREEN_effective_chrome_scale% (ds AS INTEGER)
+    DIM m AS INTEGER
+    m% = ds%
+    IF m% < 1 THEN m% = 1
+    SCREEN_effective_chrome_scale% = SCALE_resolve_one%(CFG.TOOLBAR_SCALE_OVR%, m%, CFG.SCALE_RATIO_TOOLBAR!, 1, 4)
 END FUNCTION
 
 
@@ -301,6 +294,53 @@ END FUNCTION
 
 
 ''
+' Minimum viewport WIDTH a scale must leave for the chrome to fit. `relaxed` picks the
+' floor policy: FALSE = the protective auto-detect floor (comfortable ~320px canvas,
+' SCREEN_chrome_min_w&); TRUE = an EXPLICIT user request — same docked-chrome width
+' (toolbox + layers + edit bar) but only a CHROME_MIN_CANVAS_RELAXED canvas, so the user
+' can force a larger scale on a small desktop instead of it reverting to 1x. WIN_MIN_*
+' still clamps on top at the call sites. See CHROME_MIN_CANVAS_RELAXED in SCREEN.BI.
+' @param tbScale INTEGER Toolbar/chrome scale that will render
+' @param relaxed INTEGER TRUE for an explicit user scale request, FALSE for auto-detect
+' @return LONG - Minimum viewport width in pixels
+'
+FUNCTION SCREEN_fit_min_w& (tbScale AS INTEGER, relaxed AS INTEGER)
+    IF relaxed% THEN
+        DIM toolboxW AS LONG
+        toolboxW&        = 4 * (11 * tbScale%) + 3 * (1 * tbScale%) + 2
+        SCREEN_fit_min_w& = toolboxW& + 100 + 20 + CHROME_MIN_CANVAS_RELAXED
+    ELSE
+        SCREEN_fit_min_w& = SCREEN_chrome_min_w&(tbScale%)
+    END IF
+END FUNCTION
+
+
+''
+' Minimum viewport HEIGHT a scale must leave for the chrome to fit. Companion to
+' SCREEN_fit_min_w&. The relaxed height still keeps the full toolbar-column height
+' (tbColH — the docked toolbar/organizer/drawer must render) and only shrinks the
+' canvas contribution, so the binding constraint on short screens stays the real chrome.
+' @param tbScale INTEGER Toolbar/chrome scale that will render
+' @param relaxed INTEGER TRUE for an explicit user scale request, FALSE for auto-detect
+' @return LONG - Minimum viewport height in pixels
+'
+FUNCTION SCREEN_fit_min_h& (tbScale AS INTEGER, relaxed AS INTEGER)
+    IF relaxed% THEN
+        DIM tbColH AS LONG, canvasColH AS LONG
+        tbColH&     = (196 * tbScale%) + 24
+        canvasColH& = 12 + CHROME_MIN_CANVAS_RELAXED + 11 + 12 ' menu + small canvas + status + palette
+        IF tbColH& > canvasColH& THEN
+            SCREEN_fit_min_h& = tbColH&
+        ELSE
+            SCREEN_fit_min_h& = canvasColH&
+        END IF
+    ELSE
+        SCREEN_fit_min_h& = SCREEN_chrome_min_h&(tbScale%)
+    END IF
+END FUNCTION
+
+
+''
 ' Detects optimal display scale based on desktop resolution.
 ' Chrome-aware: accounts for toolbar, organizer, drawer, layers panel,
 ' edit bar, menu bar, status bar, and palette strip when choosing scale.
@@ -361,8 +401,9 @@ FUNCTION SCREEN_detect_display_scale% ()
         vpW& = targetW& \ scale%
         vpH& = targetH& \ scale%
         
-        ' Estimate toolbar scale for this viewport
-        estTB% = SCREEN_estimate_toolbar_scale%(vpW&, vpH&)
+        ' Chrome scale that will actually render at this display scale (ratio-based,
+        ' matches SCALE_resolve_widgets), not a viewport-size guess.
+        estTB% = SCREEN_effective_chrome_scale%(scale%)
         
         ' Calculate chrome-aware minimums
         minW& = SCREEN_chrome_min_w&(estTB%)
@@ -438,9 +479,11 @@ SUB SCREEN_set_display_scale (newScale AS INTEGER)
         newVpH& = ((SCREEN_desktop_h& * 9) \ 10) \ clampedScale%
         newVpW& = (newVpW& \ 2) * 2
         newVpH& = (newVpH& \ 2) * 2
-        estTB%  = SCREEN_estimate_toolbar_scale%(newVpW&, newVpH&)
-        minW&   = SCREEN_chrome_min_w&(estTB%)
-        minH&   = SCREEN_chrome_min_h&(estTB%)
+        estTB%  = SCREEN_effective_chrome_scale%(clampedScale%)
+        ' Explicit user request (Settings / hotkey): relaxed floor so a deliberate
+        ' larger scale is honoured on a small desktop instead of reverting to 1x.
+        minW&   = SCREEN_fit_min_w&(estTB%, -1)
+        minH&   = SCREEN_fit_min_h&(estTB%, -1)
         IF CFG.WIN_MIN_WIDTH% > minW& THEN minW& = CFG.WIN_MIN_WIDTH%
         IF CFG.WIN_MIN_HEIGHT% > minH& THEN minH& = CFG.WIN_MIN_HEIGHT%
         IF (newVpW& >= minW& AND newVpH& >= minH&) OR clampedScale% <= 1 THEN EXIT DO
@@ -757,9 +800,11 @@ SUB SCREEN_init ()
     ' Safety: if viewport went below chrome-aware minimum, reduce scale as last resort
     DIM minW     AS LONG, minH AS LONG
     DIM safetyTB AS INTEGER
-    safetyTB% = SCREEN_estimate_toolbar_scale%(SCRN.w&, SCRN.h&)
-    minW&     = SCREEN_chrome_min_w&(safetyTB%)
-    minH&     = SCREEN_chrome_min_h&(safetyTB%)
+    safetyTB% = SCREEN_effective_chrome_scale%(SCRN.displayScale%)
+    ' Explicit scale (UI_SCALE/DISPLAY_SCALE set) relaxes the min-canvas floor so a
+    ' saved explicit scale survives relaunch; pure Auto keeps the protective floor.
+    minW&     = SCREEN_fit_min_w&(safetyTB%, scaleIsExplicit%)
+    minH&     = SCREEN_fit_min_h&(safetyTB%, scaleIsExplicit%)
     IF CFG.WIN_MIN_WIDTH% > 0 AND CFG.WIN_MIN_WIDTH% > minW& THEN minW& = CFG.WIN_MIN_WIDTH%
     IF CFG.WIN_MIN_HEIGHT% > 0 AND CFG.WIN_MIN_HEIGHT% > minH& THEN minH& = CFG.WIN_MIN_HEIGHT%
     DO WHILE (SCRN.w& < minW& OR SCRN.h& < minH&) AND SCRN.displayScale% > 1
@@ -781,9 +826,9 @@ SUB SCREEN_init ()
             SCRN.h& = maxVpH&
         END IF
         ' Recompute chrome-aware minimums for the new viewport
-        safetyTB% = SCREEN_estimate_toolbar_scale%(SCRN.w&, SCRN.h&)
-        minW&     = SCREEN_chrome_min_w&(safetyTB%)
-        minH&     = SCREEN_chrome_min_h&(safetyTB%)
+        safetyTB% = SCREEN_effective_chrome_scale%(SCRN.displayScale%)
+        minW&     = SCREEN_fit_min_w&(safetyTB%, scaleIsExplicit%)
+        minH&     = SCREEN_fit_min_h&(safetyTB%, scaleIsExplicit%)
         IF CFG.WIN_MIN_WIDTH% > 0 AND CFG.WIN_MIN_WIDTH% > minW& THEN minW& = CFG.WIN_MIN_WIDTH%
         IF CFG.WIN_MIN_HEIGHT% > 0 AND CFG.WIN_MIN_HEIGHT% > minH& THEN minH& = CFG.WIN_MIN_HEIGHT%
         _LOGWARN "SCREEN_init: viewport too small at " + _TRIM$(STR$(SCRN.displayScale% + 1)) + "x, reducing scale to " + _TRIM$(STR$(SCRN.displayScale%)) + "x (viewport now " + _TRIM$(STR$(SCRN.w&)) + "x" + _TRIM$(STR$(SCRN.h&)) + ")"


### PR DESCRIPTION
Four related display/UI robustness fixes, prompted by a user report of DRAW rendering at 1x (tiny chrome, buried canvas) on a 1366x768 Kubuntu laptop.

## Fixes

1. **Scale on short/narrow desktops** — the chrome-fit safety checks sized their minimum viewport from a viewport-size *estimate* instead of the toolbar scale that actually renders (`master * SCALE_RATIO_TOOLBAR`, ~0.5). The estimate over-reported chrome height by ~2x, so any desktop shorter than ~900px (e.g. 1366x768) had its auto-detected 2x knocked down to 1x. Also: an **explicit** UI Scale (Settings / hotkey) was clamped by the same protective floor auto-detect uses and written back to `UI_SCALE`, so choosing 2x on a small screen silently reverted to 1x. Explicit requests now use a relaxed floor; auto-detect stays protective.

2. **Color panels covered the palette dropdown** — the Color Mixer and Advanced Color Picker blit directly to screen 0 after the canvas upscale, so popups can't z-order above them. Added the bottom-right palette-name dropdown (`PALETTE_MENU_VISIBLE%`) to both panels' popup skip-list, matching the existing menu-bar / layer-context guards.

3. **Tooltips wrap to their container** — tooltips assumed the screen/window, so long text spilled off the right edge (floating) or was clipped mid-word (Settings dialog, e.g. the "MASTER UI scale…" help). Added one shared `TOOLTIP_wrap_line` helper; each renderer now wraps to *its own* container (window vs. dialog content area). Cap is character-based so it scales with the UI-scaled dialog font.

4. **`MOUSE_MAC_*` unused-variable warnings** — those globals are used only inside `$IF MAC` blocks, so Windows/Linux builds warned on four unused vars each build. Wrapped the declarations in `$IF MAC`.

## Testing

Built and verified on real hardware at both extremes:
- **Windows @ 1366x768** (the reported repro): now holds 2x; explicit scale honored and throttled to the max that fits instead of reverting.
- **macOS @ 1168x755**: auto-detects 2x (algorithm path); tooltips wrap within the pane.
- **Linux @ 3840x2160 (4K)**: no regression.
- Clean builds (exit 0, no warnings) on macOS and Windows; warning-free on the non-mac path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)